### PR TITLE
Update Policy creation 'towhat' field documentation

### DIFF
--- a/api/reference/policies.adoc
+++ b/api/reference/policies.adoc
@@ -216,7 +216,7 @@ POST /api/policies
   "name" : "sample_policy",
   "description" : "Sample Policy",
   "mode" : "compliance",
-  "towhat" : "ManageIQ::Providers::Redhat::InfraManager",
+  "towhat" : "Vm",
   "condition_ids" : [11, 12],
   "policy_contents" : [
     {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1659899
https://bugzilla.redhat.com/show_bug.cgi?id=1663562

With the above bugs and PRs, it was determined that the documentation - which was used to test the `Policy` create action in the API - for the `towhat` value was no longer reflective of a valid value for that field.

This change updates the documentation to reflect [recent changes which added an inclusion whitelist](https://github.com/ManageIQ/manageiq/pull/18032) for `towhat` values on creation of Policies.
