### PR TITLE
Rename manageiq_docs to manageiq-documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ManageIQ Documentation
 
-[![Build Status](https://travis-ci.org/ManageIQ/manageiq_docs.svg?branch=master)](https://travis-ci.org/ManageIQ/manageiq_docs)
-[![Join the chat at https://gitter.im/ManageIQ/manageiq_docs](https://badges.gitter.im/ManageIQ/manageiq_docs.svg)](https://gitter.im/ManageIQ/more_core_extensions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/ManageIQ/manageiq-documentation.svg?branch=master)](https://travis-ci.org/ManageIQ/manageiq_docs)
+[![Join the chat at https://gitter.im/ManageIQ/manageiq_docs](https://badges.gitter.im/ManageIQ/manageiq_docs.svg)](https://gitter.im/ManageIQ/manageiq_docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This documentation site is a [Jekyll](https://github.com/jekyll/jekyll) based site for the ManageIQ documentation.
 


### PR DESCRIPTION
NOTE: The gitter channel is still not renamed yet

@chessbyte Please review