### PR TITLE
Change links from https://access.redhat.com/documentation to equivalent in manageiq.org

### DIFF
--- a/_includes/create-playbook-service-catalog-item.md
+++ b/_includes/create-playbook-service-catalog-item.md
@@ -5,7 +5,7 @@
     inventory. Check your inventory and add the appropriate resources
     before creating an Ansible service. For more information, see
     [Automation Management
-    Providers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/managing_providers/#automation_management_providers)
+    Providers](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#automation-management-providers)
     in *Managing Providers*.
 
   - Debugging verbosity is available for Ansible playbook catalog items.

--- a/_includes/introduction.md
+++ b/_includes/introduction.md
@@ -143,7 +143,7 @@ Additionally, the following must be configured to use {{ site.data.product.title
     cloud instances that you want to control.
 
   - For more information, see
-    [SmartProxies](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/general_configuration/#smartproxies)
+    [SmartProxies](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#smartproxies)
     in the {{ site.data.product.title_short }} *General Configuration* guide.
 
 ### Terminology

--- a/_includes/openscap/openscap-overview.md
+++ b/_includes/openscap/openscap-overview.md
@@ -6,7 +6,7 @@ OpenSCAP is an auditing tool that is used for hardening the security of your ent
 
   - See Red Hat’s [Security Data](https://www.redhat.com/security/data/metrics/) page for more details about this content. In particular, the SCAP source data stream files index provides examples of security advisories that are used by the built-in OpenSCAP policy profile. Each of these security advisories has a severity that ranges from low to critical. With the built-in OpenSCAP policy profile, any image that fails a security check against an advisory with at least a high severity is marked as non-compliant.
 
-  - For more information about control and compliance policies, and creating and assigning policy profiles in {{ site.data.product.title_short }}, see the [Policies and Profiles Guide](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/policies_and_profiles_guide/).
+  - For more information about control and compliance policies, and creating and assigning policy profiles in {{ site.data.product.title_short }}, see the [Policies and Profiles Guide](https://www.manageiq.org/docs/reference/latest/policies_and_profiles_guide/index.html).
 
 
 {{ site.data.product.title_short }} can initiate scanning of container images in the following ways:

--- a/_includes/openstack/adding-an-openstack-cloud-provider.md
+++ b/_includes/openstack/adding-an-openstack-cloud-provider.md
@@ -11,7 +11,7 @@ with the `admin` tenant.
 In OpenStack, you must add `admin` as a member of all tenants that users
 want to access and use in {{ site.data.product.title_short }}.
 
-<a href="https://access.redhat.com/documentation/en-us/red_hat_cloudforms/5.0-beta/html-single/managing_infrastructure_and_inventory/index#tenants" target="_blank">Cloud
+<a href="https://www.manageiq.org/docs/reference/latest/managing_infrastructure_and_inventory/index.html#cloud-tenants" target="_blank">Cloud
 Tenants</a> in *Managing Infrastructure and Inventory* for information on working
 with OpenStack tenants (projects) in {{ site.data.product.title_short }}.
 
@@ -178,6 +178,6 @@ To authenticate the provider using a self-signed Certificate Authority (CA), con
 
   - Collecting capacity and utilization data from an OpenStack cloud
     provider requires selecting the **Collect for All Clusters** option
-    under **Configuration**, in the settings menu. For information, see <a href="https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#capacity-and-utilization-collections" target="_blank">Capacity and Utilization Collections</a> in the *General Configuration Guide*.
+    under **Configuration**, in the settings menu. For information, see <a href="https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#capacity-and-utilization-collection" target="_blank">Capacity and Utilization Collections</a> in the *General Configuration Guide*.
 
 </div>

--- a/_includes/provider-ocp-add-container.md
+++ b/_includes/provider-ocp-add-container.md
@@ -71,7 +71,7 @@
         To obtain a token for your provider, run the `oc get secret`
         command on your provider; see [Obtaining an OpenShift Container
         Platform Management
-        Token](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#Obtaining_OpenShift_Container_Platform_Management_Token).
+        Token](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#obtaining-an-openshift-container-platform-management-token).
 
         For example:
 

--- a/deployment_planning_guide/_topics/planning.md
+++ b/deployment_planning_guide/_topics/planning.md
@@ -87,7 +87,7 @@ Some roles are also dependent on other roles. For example, because the
 {{ site.data.product.title_short }} user interface relies on the API for access, the
 Web Services role must be enabled with the User Interface role for users
 to log in to the appliance. See [Server
-Roles](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/general_configuration/configuration#server-roles)
+Roles](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#server-roles)
 in *General Configuration* for details on each server role and its
 function.
 
@@ -98,7 +98,7 @@ worker and database tasks between appliances. One example of this is to
 implement a highly available configuration so that certain appliances
 are running the PostgreSQL database and providing failover. For more
 details about configuring high availability, see the [*High Availability
-Guide*](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/high_availability_guide/).
+Guide*](https://www.manageiq.org/docs/reference/latest/high_availability_guide/index.html).
 
 The following provides a summary of types of appliances:
 

--- a/general_configuration/_topics/configuration.md
+++ b/general_configuration/_topics/configuration.md
@@ -877,7 +877,7 @@ If you are using the {{ site.data.product.title }} control feature set, then you
 the ability to connect to a Web console for virtual machines that are
 registered to a host. To use this feature, you must have VNC installed,
 [VMware’s WebMKS SDK enabled in
-{{ site.data.product.title_short }}](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/managing_infrastructure_and_inventory/sect_virtual_machines#vnc_and_spice_consoles),
+{{ site.data.product.title_short }}](https://www.manageiq.org/docs/reference/latest/managing_infrastructure_and_inventory/index.html#configuring-webmks-support-in-manageiq),
 or the VMRC native desktop application installed for your environment.
 
 <div class="note">
@@ -3388,7 +3388,7 @@ Appliances](#changing-the-password-on-the-worker-appliances).
 <div class="note">
 
 See [Appliance
-Types](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/deployment_planning_guide/#appliance-types)
+Types](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#appliance-types)
 in the *Deployment Planning Guide* for a summary of different types of
 appliances.
 

--- a/high_availability_guide/_topics/ha_roles.md
+++ b/high_availability_guide/_topics/ha_roles.md
@@ -24,9 +24,9 @@ server roles and zones.
 02](../images/cloudforms_ha_architecture_431939_0917_ece-02.png)
 
 See
-[Regions](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#regions)
+[Regions](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#regions)
 and
-[Servers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#servers)
+[Servers](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#servers)
 in *General Configuration* for more information on configuring servers
 and roles.
 

--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -13,7 +13,7 @@ the non-database {{ site.data.product.title_short }} appliances.
 1.  Deploy a {{ site.data.product.title_short }} appliance with an extra (and
     unpartitioned) disk for the database at a size appropriate for your
     deployment. For recommendations on disk space, see [Database
-    Requirements](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/deployment_planning_guide/introduction#database-requirements)
+    Requirements](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#database-requirements)
     in the *Deployment Planning Guide*.
 
 2.  Configure time synchronization on the appliance by editing
@@ -242,7 +242,7 @@ standby appliance to the cluster.
     unpartitioned) disk for the database that is the same size as the
     primary database-only appliance, as it will contain the same data.
     For recommendations on disk space, see [Database
-    Requirements](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/deployment_planning_guide/introduction#database-requirements)
+    Requirements](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#database-requirements)
     in the *Deployment Planning Guide*.
 
 2.  Configure time synchronization on the appliance by editing

--- a/high_availability_guide/_topics/updating_ha.md
+++ b/high_availability_guide/_topics/updating_ha.md
@@ -31,7 +31,7 @@ Appliances must be subscribed to the following channels:
 If any appliance shows it is not registered or is missing a subscription
 to any of these channels, see *Registering and Updating {{ site.data.product.title }}*
 in [General
-Configuration](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/)
+Configuration](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html)
 to register and subscribe the appliance.
 
 **Updating the Appliances.**

--- a/installing_on_microsoft_azure/_topics/installation.md
+++ b/installing_on_microsoft_azure/_topics/installation.md
@@ -475,9 +475,9 @@ storage connection string again using the following commands:
     data.
 
   - See [Database
-    Requirements](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/deployment_planning_guide/#database-requirements)
+    Requirements](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#database-requirements)
     for some general guidelines for your database requirements.
 
-  - For information about Azure ports used by {{ site.data.product.title_short }},
+  - For information about ports used by {{ site.data.product.title_short }},
     see
-    <https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/appliance_hardening_guide/#chap_red_hat_cloudforms_security_guide_firewall>.
+    <https://www.manageiq.org/docs/reference/latest/appliance_hardening_guide/index.html#configuring-firewall-ports>.

--- a/installing_on_openshift_container_platform/_topics/appe-saml-authentication-example.md
+++ b/installing_on_openshift_container_platform/_topics/appe-saml-authentication-example.md
@@ -25,9 +25,8 @@ The configuration map includes the following parameters:
     <div class="important">
 
     Enabling external authentication must be done from the
-    {{ site.data.product.title_short }} user interface; see [Configuring External
-    Authentication](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/managing_authentication_for_cloudforms/external_auth)
-    in *Managing Authentication* for details.
+    {{ site.data.product.title_short }} user interface; see the Authentication section
+    in the [User Reference](https://www.manageiq.org/docs/reference/) for details.
 
     </div>
 

--- a/integration_with_openshift_container_platform/_topics/ocp-config-cfmiq.md
+++ b/integration_with_openshift_container_platform/_topics/ocp-config-cfmiq.md
@@ -19,5 +19,5 @@ To enable these server roles:
 {% include cap-util-assign-server-roles.md %}
 
 For more information, see [Capacity and Utilization
-Collection](https://www.ibm.com/support/knowledgecenter/SSFC4F_2.0.0/Infra_mgmt/deployment_planning_guide/index.html#capacity-and-utilization-collection)
+Collection](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#capacity-and-utilization-collection)
 in the *Deployment Planning Guide*.

--- a/managing_authentication/_topics/authentication_overview.md
+++ b/managing_authentication/_topics/authentication_overview.md
@@ -18,7 +18,7 @@ with their credentials.
 
 For further information on managing users, groups, and account roles,
 see [Access
-Control](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#access-control)
+Control](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#access-control)
 in *General Configuration*.
 
 </div>
@@ -45,7 +45,7 @@ To change authentication settings:
       - To configure authentication locally using the Virtual Management
         Database (VMDB), choose **Database**. This is the default
         method. See [Creating a
-        User](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#creating_a_user)
+        User](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#creating-a-user)
         in *General Configuration* to create users from
         {{ site.data.product.title_short }}.
 

--- a/managing_authentication/_topics/external_ad.md
+++ b/managing_authentication/_topics/external_ad.md
@@ -152,7 +152,7 @@ From the {{ site.data.product.title_short }} user interface:
 
 Make sure the user’s Active Directory groups for the appliance are
 created and appropriate roles assigned to those groups. See
-[Roles](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#roles)
+[Roles](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#roles)
 in *General Configuration* for more information.
 
 </div>

--- a/managing_authentication/_topics/ldap.md
+++ b/managing_authentication/_topics/ldap.md
@@ -147,7 +147,7 @@ To configure {{ site.data.product.title_short }} to use LDAP for authentication:
             must be defined in the VMDB where the User ID is the same as
             the user’s name in your directory service typed in
             lowercase. See [Creating a
-            User](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#creating_a_user)
+            User](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#creating-a-user)
             in *General Configuration* for steps on creating users.
 
             </div>

--- a/managing_authentication/_topics/saml.md
+++ b/managing_authentication/_topics/saml.md
@@ -214,12 +214,12 @@ to work with {{ site.data.product.title_short }}:
 
 2.  On your {{ site.data.product.title_short }} appliance, create the equivalent
     groups. See [Creating a User
-    Group](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#creating-a-user-group)
+    Group](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#creating-a-group)
     in *General Configuration*.
 
 3.  On your {{ site.data.product.title_short }} appliance, assign EVM roles to the
     groups. See [Creating a
-    Role](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#creating-a-role)
+    Role](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#creating-a-role)
     in *General Configuration*.
 
 </div>

--- a/managing_infrastructure_and_inventory/_topics/data_optimization_features.md
+++ b/managing_infrastructure_and_inventory/_topics/data_optimization_features.md
@@ -14,10 +14,10 @@ in the *Deployment Planning Guide*.
     sections in the *Deployment Planning Guide*:
 
       - [Assigning the Capacity and Utilization Server
-        Roles](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/deployment_planning_guide/Capacity_Planning#assigning_the_capacity_and_utilization_server_roles)
+        Roles](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#assigning-the-capacity-and-utilization-server-roles)
 
       - [Capacity and Utilization Data
-        Collected](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/deployment_planning_guide/capacity_planning#data_collected)
+        Collected](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#capacity-and-utilization-data-collected)
 
 </div>
 

--- a/managing_infrastructure_and_inventory/_topics/tenants.md
+++ b/managing_infrastructure_and_inventory/_topics/tenants.md
@@ -39,7 +39,7 @@ have visibility into these tenants.
 This section describes OpenStack cloud tenant usage. For information
 about tenants created in {{ site.data.product.title_short }} for access and resource
 control, see [Access
-Control](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#access-control)
+Control](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#access-control)
 in *General Configuration*.
 
 </div>

--- a/managing_providers/_topics/containers_providers.md
+++ b/managing_providers/_topics/containers_providers.md
@@ -38,7 +38,7 @@ containers entities except volumes can be tagged.
 This chapter provides details on managing containers providers. For
 details on working with the resources within a container environment,
 see [Container
-Entities](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_infrastructure_and_inventory/#container_entities)
+Entities](https://www.manageiq.org/docs/reference/latest/managing_infrastructure_and_inventory/index.html#container-entities)
 in *Managing Infrastructure and Inventory*.
 
 </div>

--- a/managing_providers/_topics/editing_a_containers_provider.md
+++ b/managing_providers/_topics/editing_a_containers_provider.md
@@ -71,7 +71,7 @@ connect to {{ site.data.product.title }}.
         To obtain a token for your provider, run the `oc get secret`
         command on your provider; see [Obtaining an OpenShift Container
         Platform Management
-        Token](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#Obtaining_OpenShift_Container_Platform_Management_Token).
+        Token](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#obtaining-an-openshift-container-platform-management-token).
 
         For example:
 

--- a/managing_providers/_topics/enabling_red_hat_virtualization_cu.md
+++ b/managing_providers/_topics/enabling_red_hat_virtualization_cu.md
@@ -8,12 +8,12 @@ Red Hat Virtualization provider:
     \> Server Control\]. For more information on capacity and
     utilization collection, see [Assigning the Capacity and Utilization
     Server
-    Roles](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles)
+    Roles](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#assigning-the-capacity-and-utilization-server-roles)
     in the *Deployment Planning Guide*.
 
   - For information on selecting clusters and datastores used to collect
     data, see [Capacity and Utilization
-    Collections](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#capacity-and-utilization-collections)
+    Collections](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#capacity-and-utilization-collection)
     in the *General Configuration Guide*.
 
   - In your Red Hat Virtualization environment, install the Data
@@ -26,5 +26,5 @@ Red Hat Virtualization provider:
 
       - To create a {{ site.data.product.title_short }} user in the Data Warehouse
         database, see [Data Collection for Red Hat Enterprise
-        Virtualization](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/deployment_planning_guide/#data_collection_for_rhev_33_34)
+        Virtualization](https://www.manageiq.org/docs/reference/latest/deployment_planning_guide/index.html#data-collection-for-red-hat-virtualization)
         in the *Deployment Planning Guide*.

--- a/managing_providers/_topics/hide_environment_vars.md
+++ b/managing_providers/_topics/hide_environment_vars.md
@@ -54,5 +54,5 @@ To configure user access to container environment variables:
 8.  Click **Save**.
 
 For more information about user roles, see
-[Roles](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#roles)
+[Roles](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#roles)
 in *General Configuration*.

--- a/managing_providers/index.md
+++ b/managing_providers/index.md
@@ -40,7 +40,7 @@ This guide covers working with providers and managers in
 
 For information on working with the resources contained by a provider or
 manager, see [Managing Infrastructure and
-Inventory](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_infrastructure_and_inventory/).
+Inventory](https://www.manageiq.org/docs/reference/latest/managing_infrastructure_and_inventory/index.html).
 
 {% include_relative _topics/infrastructure_providers.md %}
 

--- a/monitoring_alerts_and_reporting/_topics/to_schedule_a_report.md
+++ b/monitoring_alerts_and_reporting/_topics/to_schedule_a_report.md
@@ -99,7 +99,7 @@ Adding new Schedule details.
 <div class="note">
 
 See
-<https://access.redhat.com/documentation/en/red-hat-cloudforms/4.7/paged/general-configuration>
+<https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#outgoing-smtp-email-settings>
 in the *General Configuration* guide, to learn how to verify the address
 and validate outgoing email settings.
 

--- a/provisioning_virtual_machines_and_hosts/_topics/fulfilling_requests.md
+++ b/provisioning_virtual_machines_and_hosts/_topics/fulfilling_requests.md
@@ -69,7 +69,7 @@ quota is set for the tenant or group as a whole.
         A user creating a provisioning request must have an email
         address saved in their profile, or provisioning may fail. See
         [Creating a
-        User](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#creating_a_user)
+        User](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#creating-a-user)
         in *General Configuration* for details on configuring users.
 
         </div>

--- a/provisioning_virtual_machines_and_hosts/_topics/provisioning_requests.md
+++ b/provisioning_virtual_machines_and_hosts/_topics/provisioning_requests.md
@@ -252,7 +252,7 @@ following before creating a provision request.
 1.  Add the **ISO Datastore**. The Red Hat Virtualization Manager system
     must have already been discovered or added into the VMDB. For more
     information, see [Adding a Red Hat Enterprise Virtualization Manager
-    Provider](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#adding_a_red_hat_enterprise_virtualization_manager_provider)
+    Provider](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#adding-a-red-hat-virtualization-provider)
     in *Managing Providers*.
 
 2.  Refresh the **ISO Datastore**.
@@ -786,7 +786,7 @@ virtual machine is provisioned has it marked.
 For an example of virtual machine provisioning request using cloud-init
 via REST API, see *Provisioning a Virtual Machine Using Cloud-init* in
 the [{{ site.data.product.title }} REST
-API](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/red_hat_cloudforms_rest_api/index)
+API](https://www.manageiq.org/docs/reference/latest/rest_api/index.html#provisioning-a-virtual-machine-using-cloud-init)
 guide.
 
 </div>
@@ -1142,7 +1142,7 @@ To enable these resources for all groups, set the scope to **All**. To
 limit access to a select group, create a tag in the **Provisioning
 Scope** category with the exact name of the user group and set this tag
 on the desired resources. See
-[Tags](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/general_configuration/#regions)
+[Tags](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#regions)
 in *General Configuration* for information on creating tags.
 
 To set the scope for a datastore:

--- a/quickstart_openstack_provider_guide/_topics/catalogs-services.md
+++ b/quickstart_openstack_provider_guide/_topics/catalogs-services.md
@@ -21,9 +21,9 @@ Creating a *service catalog* involves:
 <div class="note">
 
 For more information about catalogs and services, see [Catalogs and
-Services](https://access.redhat.com/documentation/en/red-hat-cloudforms/4.7/single/provisioning-virtual-machines-and-hosts/#catalogs-services)
+Services](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#catalogs-and-services)
 from the [Provisioning Virtual Machines and
-Hosts](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/)
+Hosts](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html)
 guide.
 
 </div>

--- a/quickstart_openstack_provider_guide/index.md
+++ b/quickstart_openstack_provider_guide/index.md
@@ -100,24 +100,24 @@ Cloud instance provisioning goes through three phases:
 1.  Request: This includes ownership information, tags, virtual hardware
     requirements, the operating system, and any customization required.
     See [Provisioning
-    Requests](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/#provisioning-requests)
+    Requests](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#provisioning-requests)
     from the [Provisioning Virtual Machines and
-    Hosts](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/)
+    Hosts](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html)
     guide for more details.
 
 2.  Approval: Provisioning requests are then approved or denied. This
     phase can happen automatically or manually. See [Provisioning
     Request Approval
-    Methods](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/#provisioning-request-approval-methods)
+    Methods](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#provisioning-request-approval-methods)
     from the [Provisioning Virtual Machines and
-    Hosts](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/)
+    Hosts](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html)
     guide for more details.
 
 3.  Provision: Approved provisioning requests are executed. See [Working
     with Provisioning
-    Requests](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/#working-with-provisioning-requests)
+    Requests](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#working-with-provisioning-requests)
     from the [Provisioning Virtual Machines and
-    Hosts](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/provisioning_virtual_machines_and_hosts/)
+    Hosts](https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html)
     guide for more details.
 
 ### Provisioning an OpenStack Instance from an Image
@@ -129,9 +129,9 @@ Cloud instance provisioning goes through three phases:
 {% include openstack/storage-manager-available.md %}
 
 For more information, see [Storage
-Managers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#storage_managers)
+Managers](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#storage-managers)
 from the [Managing
-Providers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/)
+Providers](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html)
 guide.
 
 ### Managing Block Storage
@@ -166,9 +166,9 @@ To take a volume snapshot:
 
 For more information about available options for block storage resources
 in {{ site.data.product.title_short }}, see [OpenStack Block Storage
-Managers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#openstack_block_storage_managers)
+Managers](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#openstack-block-storage-managers)
 (from the [Managing
-Providers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/)
+Providers](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html)
 guide).
 
 ### Managing Object Storage
@@ -210,9 +210,8 @@ and features frequently used by specific tenants.
 
 This capability is made possible through the *Automate* model. See
 [Understanding the Automate
-Model](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/scripting_actions_in_cloudforms/#understanding-the-automate-model)
-from the [Scripting Actions in
-CloudForms](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/scripting_actions_in_cloudforms/)
+Model](https://www.manageiq.org/docs/reference/latest/scripting_actions/index.html#understanding-the-automate-model)
+from the [Scripting Actions in ManageIQ](https://www.manageiq.org/docs/reference/latest/scripting_actions/index.html)
 guide for more details.
 
 </div>
@@ -237,9 +236,9 @@ does, create a custom button for any tenant within the OpenStack Cloud
 
 The button will show in the object type you added the button to. See
 [Invoking
-Automate](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/scripting_actions_in_cloudforms/#invoking-automate)
+Automate](https://www.manageiq.org/docs/reference/latest/scripting_actions/index.html#invoking-automate)
 from the [Scripting Actions in
-CloudForms](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/scripting_actions_in_cloudforms/)
+ManageIQ](https://www.manageiq.org/docs/reference/latest/scripting_actions/index.html)
 guide for more in-depth coverage.
 
 # Managing Keypairs

--- a/rest_api/_topics/scan_containers.md
+++ b/rest_api/_topics/scan_containers.md
@@ -6,7 +6,7 @@ Scan containers using SmartState Analysis.
 
   - Scanning containers requires enabling the SmartProxy server role.
     See
-    [Servers](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/general_configuration/#servers)
+    [Servers](https://www.manageiq.org/docs/reference/latest/general_configuration/index.html#servers)
     in the *General Configuration Guide* for information on server
     roles.
 

--- a/scripting_actions/_topics/ansible_method.md
+++ b/scripting_actions/_topics/ansible_method.md
@@ -8,7 +8,7 @@ parameters specified by the user.
 
   - You must first sync your playbook repositories before using them to
     create a method. See [Adding a Playbook
-    Repository](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/managing_providers/automation_management_providers#adding-a-playbook-repository)
+    Repository](https://www.manageiq.org/docs/reference/latest/managing_providers/index.html#adding-a-playbook-repository)
     in *Managing Providers* for information on initial playbook
     repository set-up.
 

--- a/scripting_actions/_topics/to_create_an_ansible_playbook_button.md
+++ b/scripting_actions/_topics/to_create_an_ansible_playbook_button.md
@@ -7,7 +7,7 @@ can be defined for any object type available.
 
 <div class="note">
 
-An Ansible Playbook catalog item must exist in order to create an Ansible Playbook custom button. For more information, see <a href="https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html/provisioning_virtual_machines_and_hosts/catalogs-services#create-playbook-service-catalog-item" target="_blank">Creating an Ansible Playbook Service Catalog Item</a> in the Provisioning Virtual Machines and Hosts guide.
+An Ansible Playbook catalog item must exist in order to create an Ansible Playbook custom button. For more information, see <a href="https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#creating-an-ansible-playbook-service-catalog-item" target="_blank">Creating an Ansible Playbook Service Catalog Item</a> in the Provisioning Virtual Machines and Hosts guide.
 
 </div>
 
@@ -50,7 +50,7 @@ An Ansible Playbook catalog item must exist in order to create an Ansible Playbo
         **Specific Hosts** and leave the associated text field blank.
 
       - To use admin-specified host values, remove the **Hosts** field when creating the dialog the service uses. In this
-        configuration, the field will not appear to users. See <a href="https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/provisioning_virtual_machines_and_hosts/catalogs-services#service-dialogs" target="_blank">Service Dialogs</a> for information on generating a service dialog.
+        configuration, the field will not appear to users. See <a href="https://www.manageiq.org/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html#service-dialogs" target="_blank">Service Dialogs</a> for information on generating a service dialog.
 
     </div>
 


### PR DESCRIPTION
Note, there are still some links remaining for which there are currently no equivalents in manageiq.org.

```sh
$ ag "access.redhat.com/documentation/en-us/red_hat_cloudforms"
_includes/smartstate.md:3:Support](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/support_matrix/#smart_state_analysis_support)
_includes/smartstate.md:5:Analysis](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/managing_providers/#running-a-smartstate-analysis)
creating_a_service_for_vm_provisioning/_topics/provisioning_a_vm_using_ssui.md:31:Guide](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/self_service_user_interface_guide/)
managing_infrastructure_and_inventory/_topics/data_optimization_features.md:7:Machine](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/deployment_planning_guide/#planning-where-to-put-a-new-virtual-machine)
managing_infrastructure_and_inventory/_topics/container_entities.md:106:OpenSCAP*](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html-single/scanning_container_images_in_cloudforms_with_openscap/)
```

Will address these in future PRs as links are created in manageiq.org.