### PR TITLE
[IVANCHUK] Make ivanchuk act as the primary legacy docs repo

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -6,9 +6,9 @@ manageiq:
   site_name: ManageIQ Documentation
   site_url: http://manageiq.org
   branches:
-    master:
-      name: Nightly Build
-      dir: master
+    ivanchuk:
+      name: Ivanchuk
+      dir: ivanchuk
     hammer:
       name: Hammer
       dir: hammer
@@ -21,22 +21,3 @@ manageiq:
     euwe:
       name: Euwe
       dir: euwe
-cfme:
-  name: CloudForms Management Engine
-  author: CloudForms Management Engine Documentation Project <contact@manageiq.org>
-  site: commercial
-  site_name: CloudForms Management Engine Documentation
-  site_url: https://www.redhat.com/en/technologies/cloud-computing/cloudforms
-  branches:
-    5.10.z:
-      name: 5.10.z
-      dir: cfme/5.10.z
-    5.9.z:
-      name: 5.9.z
-      dir: cfme/5.9.z
-    5.8.z:
-      name: 5.8.z
-      dir: cfme/5.8.z
-    5.7.z:
-      name: 5.7.z
-      dir: cfme/5.7.z


### PR DESCRIPTION
This is required for when manageiq.org switches to jansa being markdown based.