### PR TITLE
Fix appliance_rpm_dir

### DIFF
--- a/_data/product.yml
+++ b/_data/product.yml
@@ -4,15 +4,4 @@ title_short: ManageIQ
 title_short_l: manageiq
 title_abbr: miq
 title_abbr_uc: MIQ
-# virt-product-title: oVirt Engine
-# product-repo_list: cf-me-5.10-for-rhel-7-rpms rhel-7-server-ansible-2.6-rpms rhel-7-server-extras-rpms rhel-7-server-optional-rpms rhel-7-server-rpms
-# product-repo_list_lb: cf-me-5.10-for-rhel-7-rpms + \
-#   rhel-7-server-ansible-2.6-rpms + \
-#   rhel-7-server-extras-rpms + \
-#   rhel-7-server-optional-rpms + \
-#   rhel-7-server-rpms
-# product-repo_cfme: cf-me-5.10-for-rhel-7-rpms
-# product-repo_ansible: rhel-7-server-ansible-2.6-rpms
-# product-repo_extras: rhel-7-server-extras-rpms
-# product-repo_optional: rhel-7-server-optional-rpms
-# product-repo_server: rhel-7-server-rpms
+appliance_rpm_dir: /opt/manageiq/manageiq-appliance

--- a/auth/active_directory.md
+++ b/auth/active_directory.md
@@ -124,7 +124,7 @@ readable by Apache.
 
 Create the Apache configuration files
 
-    # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
+    # TEMPLATE_DIR="{{ site.data.product.appliance_rpm_dir }}/TEMPLATE"
     # cp ${TEMPLATE_DIR}/etc/pam.d/httpd-auth                         \
                         /etc/pam.d/httpd-auth
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-remote-user.conf       \

--- a/auth/ldap.md
+++ b/auth/ldap.md
@@ -104,7 +104,7 @@ Seed the sssd.conf configuration file
 file, however the template, *sssd.conf.erb*, is now delivered with
 ManageIQ which can be used to seed the */etc/sssd/sssd.conf*.
 
-    # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
+    # TEMPLATE_DIR="{{ site.data.product.appliance_rpm_dir }}/TEMPLATE"
     # mkdir -p /etc/sssd
     # cp ${TEMPLATE_DIR}/etc/sssd/sssd.conf.erb /etc/sssd/sssd.conf
     # chmod 600 /etc/sssd/sssd.conf
@@ -262,7 +262,7 @@ the SSSD cache as follows then retry:
 
 Create the Apache configuration files
 
-    # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
+    # TEMPLATE_DIR="{{ site.data.product.appliance_rpm_dir }}/TEMPLATE"
     # cp ${TEMPLATE_DIR}/etc/pam.d/httpd-auth                         \
                         /etc/pam.d/httpd-auth
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-remote-user.conf       \

--- a/auth/openid_connect.md
+++ b/auth/openid_connect.md
@@ -123,7 +123,7 @@ The following *User Session Note* mappers must be manually created:
 
 Copy the Apache OIDC template configuration files:
 
-    # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
+    # TEMPLATE_DIR="{{ site.data.product.appliance_rpm_dir }}/TEMPLATE"
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-remote-user-openidc.conf \
         /etc/httpd/conf.d/
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb \

--- a/auth/saml.md
+++ b/auth/saml.md
@@ -50,7 +50,7 @@ First ssh to the appliance as root, then create that directory:
 
 Copy the Apache remote user and SAML template configuration files:
 
-    # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
+    # TEMPLATE_DIR="{{ site.data.product.appliance_rpm_dir }}/TEMPLATE"
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-remote-user.conf        \
         /etc/httpd/conf.d/
     # cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-external-auth-saml.conf \


### PR DESCRIPTION
@jvlcek @chessbyte Please review

The /var/www/miq/system dir no longer exists (it was a leftover symlink from forever ago that is now gone in the move to RPMs.)