### PR TITLE
Fix resource_ids array parameter in example for metric_rollups request

### DIFF
--- a/api/reference/metric_rollups.md
+++ b/api/reference/metric_rollups.md
@@ -15,7 +15,9 @@ Supported query parameters:
 | Parameter         | Examples                                                                |
 | ----------------- | ----------------------------------------------------------------------- |
 | resource\_type    | VmOrTemplate, Service or any resource type that supports Metric Rollups |
-| resource\_ids     | \[id1,id2,id3, …​\]                                                     |
+| resource\_ids\[\]     | id1
+| resource\_ids\[\]     | id2
+| resource\_ids\[\]     | ...                                             |
 | capture\_interval | hourly, daily                                                           |
 | start\_date       | 2018-01-10, 2018-01-10T11:20:00Z                                        |
 | end\_date         | 2018-01-17, 2017-12-31T23:59:00Z                                        |
@@ -24,20 +26,23 @@ Supported query parameters:
 
 ``` data
 GET /api/metric_rollups?resource_type=VmOrTemplate
-                      &resource_ids=[101,102,103]
-                      &capture_interval=daily
-                      &start_date='2017-10-01'
-                      &limit=60
+                       &resource_ids[]=101
+                       &resource_ids[]=102
+                       &resource_ids[]=103
+                       &capture_interval=daily
+                       &start_date='2017-10-01'
+                       &limit=60
 ```
 
 ### Getting Hourly Metric Rollups for a range of Dates
 
 ``` data
 GET /api/metric_rollups?resource_type=Service
-                      &resource_ids=[55,56]
-                      &capture_interval=hourly
-                      &start_date='2017-11-15'
-                      &end_date='2017-11-18'
+                       &resource_ids[]=55
+                       &resource_ids[]=56
+                       &capture_interval=hourly
+                       &start_date='2017-11-15'
+                       &end_date='2017-11-18'
 ```
 
 Metric rollups can also be obtained for a specific resource as a


### PR DESCRIPTION
we don't support `...&resource_ids=[101,102,103]` 
we support `..&resource_ids[]=101&resource_ids[]=102,...` 