### PR TITLE
attribute value pair note

### DIFF
--- a/scripting_actions/_topics/to_create_a_custom_button1.md
+++ b/scripting_actions/_topics/to_create_a_custom_button1.md
@@ -10,3 +10,5 @@ Custom buttons can be migrated to other {{ site.data.product.title }} appliances
 {% include automate-custom-button.md %}
 
 The button will show in the object type you added the button to.
+
+Please note that there are two ways of creating custom buttons, and creation through the "Automation > Automate > Generic Objects" screen will necessitate adding an attribute/value pair that is not required when adding through the "Automation > Customization > Buttons" screen.


### PR DESCRIPTION
add note about attribute value pair ui discrepancy

this looks intentional and I don't think is a bug: see https://github.com/ManageIQ/manageiq-ui-classic/pull/6695

unless someone wants particularly to open as a bug for classic ui, but I say this was intentional because Harpreet was involved in the listed ticket and appears to not have thought that these two forms should be consistent. 

https://bugzilla.redhat.com/show_bug.cgi?id=1784190 is fixed and verified, this is just intended as post facto doc change