### PR TITLE
Add entry for network providers in capabilities matrix

### DIFF
--- a/capabilities_matrix/_topics/network_providers.md
+++ b/capabilities_matrix/_topics/network_providers.md
@@ -1,0 +1,27 @@
+### Network Providers
+
+The following tables outline the capabilities of {{ site.data.product.title_short }} that are known to work for various network providers.
+
+| Discovery         | Nuage | VMware NSX-t |
+| ----------------- | ----- | ------------ |
+| Cloud Tenants     | ✅     | ✅           |
+| Cloud Networks    | ✅     | ✅           |
+| Cloud Subnets     | ✅     | ✅           |
+| Security Groups   | ✅     | ✅           |
+| Security Policies | ❌     | ✅           |
+| Network Services  | ❌     | ✅           |
+| Floating IPs      | ✅     | ❌           |
+| Network Ports     | ✅     | ✅           |
+| Network Routers   | ✅     | ✅           |
+| Events            | ✅     | ❌           |
+| Metrics           | ❌     | ❌           |
+
+| Operations             | Nuage | VMware NSX-t |
+| ---------------------- | ----- | ------------ |
+| Create Cloud Network   | ✅     | ✅           |
+| Create Cloud Subnet    | ✅     | ❌           |
+| Delete Cloud Subnet    | ✅     | ❌           |
+| Delete Floating IP     | ✅     | ❌           |
+| Create Security Group  | ❌     | ✅           |
+| Delete Security Group  | ✅     | ❌           |
+| Create Security Policy | ❌     | ✅           |

--- a/capabilities_matrix/index.md
+++ b/capabilities_matrix/index.md
@@ -20,5 +20,6 @@
 
 {% include_relative _topics/automation_providers.md %}
 
-{% include_relative _topics/smartstate_analysis.md %}
+{% include_relative _topics/network_providers.md %}
 
+{% include_relative _topics/smartstate_analysis.md %}


### PR DESCRIPTION
We did not have a capabilities matrix entry for the standalone network providers (Nuage and NSX-t)