### PR TITLE
Update database instructions

### DIFF
--- a/_includes/configuration-advanced.md
+++ b/_includes/configuration-advanced.md
@@ -26,7 +26,7 @@ configuration of the appliance:
 <td><p>Restore the Virtual Management Database (VMDB) from a previous backup.</p></td>
 </tr>
 <tr class="even">
-<td><p><strong>Configure Database</strong></p></td>
+<td><p><strong>Configure Application</strong></p></td>
 <td><p>Configure the VMDB. Use this option to configure the database for the appliance after installing and running it for the first time.</p></td>
 </tr>
 <tr class="odd">

--- a/_includes/configuration-advanced.md
+++ b/_includes/configuration-advanced.md
@@ -34,58 +34,54 @@ configuration of the appliance:
 <td><p>Configure a primary or standby server for VMDB replication.</p></td>
 </tr>
 <tr class="even">
-<td><p><strong>Configure Database Maintenance</strong></p></td>
-<td><p>Configure the VMDB maintenance schedule.</p></td>
-</tr>
-<tr class="odd">
 <td><p><strong>Logfile Configuration</strong></p></td>
 <td><p>Provides options for configuring a new logfile disk volume, and changing the saved logrotate count.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Configure Application Database Failover Monitor</strong></p></td>
 <td><p>Start or stop VMDB failover monitoring.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Extend Temporary Storage</strong></p></td>
 <td><p>Add temporary storage to the appliance. The appliance formats an unpartitioned disk attached to the appliance host and mounts it at <code>/var/www/miq_tmp</code>. The appliance uses this temporary storage directory to perform certain image download functions.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Configure External Authentication (httpd)</strong></p></td>
 <td><p>Configure authentication through an IPA server.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Update External Authentication Options</strong></p></td>
 <td><p>Enable or disable external authentication methods: single sign-on, SAML, and local login. For example, if the current state is <code>Enabled</code>, the prompt indicates the option should be <code>Disabled</code>.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Generate Custom Encryption Key</strong></p></td>
 <td><p>Regenerate the encryption key used to encode plain text password.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Harden Appliance Using SCAP Configuration</strong></p></td>
 <td><p>Apply Security Content Automation Protocol (SCAP) standards to the appliance. You can view these SCAP rules in the <code>/var/www/miq/lib/appliance_console/config/scap_rules.yml</code> file.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Stop EVM Server Processes</strong></p></td>
 <td><p>Stop all server processes. You may need to do this to perform maintenance.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Start EVM Server Processes</strong></p></td>
 <td><p>Start the server. You may need to do this after performing maintenance.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Restart Appliance</strong></p></td>
 <td><p>Restart the {{ site.data.product.title_short }} appliance. You can either restart the appliance and clear the logs or just restart the appliance.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Shut Down Appliance</strong></p></td>
 <td><p>Power down the appliance and exit all processes.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><strong>Summary Information</strong></p></td>
 <td><p>Go back to the network summary screen for the {{ site.data.product.title_short }} appliance.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p><strong>Quit</strong></p></td>
 <td><p>Leave the {{ site.data.product.title_short }} appliance console.</p></td>
 </tr>

--- a/_includes/configuration-db.md
+++ b/_includes/configuration-db.md
@@ -17,7 +17,7 @@ disks; installation will fail if the disks are not blank.
 
 3.  Press **Enter** to manually configure settings.
 
-4.  Select **Configure Database** from the menu.
+4.  Select **Configure Application** from the menu.
 
 5.  You are prompted to create or fetch an encryption key.
 

--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -88,7 +88,7 @@ necessary to alter the `max_connections` setting.
 
 3.  Press **Enter** to manually configure settings.
 
-4.  Select **Configure Database** from the menu.
+4.  Select **Configure Application** from the menu.
 
 5.  You are prompted to create or fetch a security key.
 
@@ -136,7 +136,7 @@ has a region configured with a database.
 
 3.  Press **Enter** to manually configure settings.
 
-4.  Select **Configure Database** from the menu.
+4.  Select **Configure Application** from the menu.
 
 5.  You are prompted to create or fetch a security key. Since this is
     not the first {{ site.data.product.title_short }} appliance, choose **2) Fetch key from

--- a/general_configuration/_topics/configuration.md
+++ b/general_configuration/_topics/configuration.md
@@ -2913,7 +2913,7 @@ the data in the database.
 
 5.  Enter `Y` to confirm.
 
-6.  Choose `Configure Database`.
+6.  Choose `Configure Application`.
 
 7.  Enter a database region number that has not been used in your
     environment. Do not enter duplicate region numbers because this can

--- a/general_configuration/_topics/configuration.md
+++ b/general_configuration/_topics/configuration.md
@@ -3441,54 +3441,6 @@ to access the server, and restart the {{ site.data.product.title_short }} applia
 
         service evmserverd restart
 
-#### Configuring Scheduled Database Maintenance
-
-You can schedule hourly or periodic database maintenance through the
-appliance console. Performing regular PostgreSQL database maintenance
-helps to maintain a more responsive {{ site.data.product.title_short }} environment.
-
-Hourly database maintenance tasks, such as reindexing, are useful for
-highly active database tables such as metrics, workers, and servers.
-
-You also may want to perform periodic database maintenance to truncate
-empty metrics tables and reorganize the database. Periodic maintenance
-can be configured to run hourly, daily, weekly, or monthly, at a
-specified hour and on a specified day.
-
-**Note:**
-
-Periodic maintenance can impact appliance performance while it is
-running. Red Hat recommends scheduling periodic maintenance
-infrequently, and at off hours.
-
-To configure hourly and periodic database maintenance:
-
-1.  Log in to the appliance as the **root** user.
-
-2.  Enter `appliance_console`, and press **Enter**.
-
-3.  Press any key.
-
-4.  Select **Configure Database Maintenance** to configure the automatic
-    database maintenance schedule through a dialog.
-
-    1.  For **Configure Hourly Database Maintenance?** Type `y` or `n`.
-
-    2.  For **Configure Periodic Database Maintenance?** Type `y` or
-        `n`.
-
-The next options depend on the periodic database maintenance frequency
-you choose, and are specified using the same dialog. The dialog finishes
-configuration with a **"Database maintenance configuration updated"**
-message when complete.
-
-To reset your database maintenance settings, enter **Configure Database Maintenance** again from the appliance console menu, and confirm that
-you want to unconfigure the settings in the configuration dialog. This
-deletes the current settings.
-
-To configure a new database maintenance schedule, enter the **Configure Database Maintenance** menu item once again and configure the values
-using the dialog.
-
 #### Creating a Database Dump
 
 {% include database-dumps.md %}

--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -36,6 +36,13 @@ the non-database {{ site.data.product.title_short }} appliances.
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
+    For standard manageiq installations, a pre-sized database disk is already attached, initialized, encryption key generated, database configured with a region, and the application started.
+
+    2. Select **Stop evm server processes**, select `y`.
+    3. Quit from appliance console and `run systemctl disable evmserverd` to make this a standalone database server.
+
+    Alternatively, if you attached a new database disk and have not yet configured the application:
+
     2.  Select **Configure Application**.
 
     3.  Select **Create key** to create the encryption key. You can

--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -36,7 +36,7 @@ the non-database {{ site.data.product.title_short }} appliances.
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
-    2.  Select **Configure Database**.
+    2.  Select **Configure Application**.
 
     3.  Select **Create key** to create the encryption key. You can
         create a new key, or use an existing key on your system by
@@ -122,7 +122,7 @@ and secondary database-only appliances can be configured.
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
-    2.  Select **Configure Database**.
+    2.  Select **Configure Application**.
 
     3.  Configure this appliance to use the encryption key from the
         primary database-only appliance:
@@ -340,7 +340,7 @@ and any additional appliances in the region using the following steps:
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
-    2.  Select **Configure Database**.
+    2.  Select **Configure Application**.
 
     3.  Configure this appliance to use the encryption key from the
         primary database-only appliance:

--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -36,7 +36,7 @@ the non-database {{ site.data.product.title_short }} appliances.
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
-    For standard manageiq installations, a pre-sized database disk is already attached, initialized, encryption key generated, database configured with a region, and the application started.
+    For standard {{ site.data.product.title_short }} installations, a pre-sized database disk is already attached, initialized, encryption key generated, database configured with a region, and the application started.
 
     2. Select **Stop evm server processes**, select `y`.
     3. Quit from appliance console and `run systemctl disable evmserverd` to make this a standalone database server.


### PR DESCRIPTION
Updated documentation:

* Configure Database was renamed to Configure Application as of jansa release
* Database Maintenance section was removed as of gaprindashvili 
* High availability guide was updated since the default manageiq installation already has a database disk attached, initialized, database setup and the application running.