### PR TITLE
Remove "Discovery - Providers" capability from container_providers

### DIFF
--- a/capabilities_matrix/_topics/container_providers.md
+++ b/capabilities_matrix/_topics/container_providers.md
@@ -8,7 +8,6 @@ The following table outlines the capabilities of {{ site.data.product.title_shor
 | Track Container Image Relationship      | ✅                                      | ✅                                     | ✅         | ✅                                      |
 | Capacity & Utilization                  | ✅                                      | ✅                                     | ✅         | ❌                                      |
 | Capture Container Event Timelines       | ✅                                      | ✅                                     | ✅         | ✅                                      |
-| Discovery - Provider                    | ❌                                      | ❌                                     | ❌         | ❌                                      |
 | Reporting                               | ✅                                      | ✅                                     | ✅         | ✅                                      |
 | Chargeback                              | ✅                                      | ✅                                     | ✅         | ✅ (Allocation only)                    |
 | Remote Cockpit Node Access              | ✅                                      | ❌                                     | ❌         | ❌                                      |


### PR DESCRIPTION
The entire provider discovery feature has been removed, there is a lingering line in the container providers which indicates no support which is correct but confusing now that no providers at all support this.

Feature removed in: https://github.com/ManageIQ/manageiq-ui-classic/pull/7584
The rest of the provider types had this removed from the documentation in: #1542