### PR TITLE
'Add to access token' flag set to ON to make it works with SSUI

### DIFF
--- a/auth/openid_connect.md
+++ b/auth/openid_connect.md
@@ -109,7 +109,7 @@ The following *Group Membership* mapper must be manually created:
 
 | Name   | Consent Required | Mapper Type      | Token Claim Name | Full group path | Add to ID token | Add to access token | Add to userinfo |
 | ------ | ---------------- | ---------------- | ---------------- | --------------- | --------------- | ------------------- | --------------- |
-| groups | OFF              | Group Membership | groups           | OFF             | ON              | OFF                 | OFF             |
+| groups | OFF              | Group Membership | groups           | OFF             | ON              | ON                  | OFF             |
 
 The following *User Session Note* mappers must be manually created:
 


### PR DESCRIPTION
"Add to access token" had to be ON to make the OIDC auth work with the Self Service UI. 