### PR TITLE
Update the OCP Add Container Docs for Alerts/Metrics

### DIFF
--- a/_includes/provider-ocp-add-container.md
+++ b/_includes/provider-ocp-add-container.md
@@ -10,18 +10,7 @@
 5.  Enter the appropriate **Zone** for the provider. If you do not
     specify a zone, it is set to `default`.
 
-6.  From the **Alerts** list, select **Prometheus** to enable external
-    alerts. Selecting **Prometheus** adds an **Alerts** tab to the lower
-    pane to configure the Prometheus service. Alerts are disabled by
-    default.
-
-7.  From the **Metrics** list, select **Hawkular** or **Prometheus** to
-    collect capacity and utilization data, or leave as **Disabled**.
-    Selecting **Prometheus** or **Hawkular** adds a **Metrics** tab to
-    the lower pane for further configuration. Metrics are disabled by
-    default.
-
-8.  In the **Default** tab, configure the following for the OpenShift
+6.  In the **Default** tab, configure the following for the OpenShift
     provider:
 
     1.  Select a **Security Protocol** method to specify how to
@@ -45,7 +34,7 @@
             from `/etc/origin/master/ca.crt`. Paste the output (a block
             of text starting with `-----BEGIN CERTIFICATE-----`) into
             the **Trusted CA Certificates** field.
-            
+
           - **SSL without validation**: Authenticate the provider
             insecurely (not recommended).
 
@@ -54,7 +43,7 @@
         **Important:**
 
         The **Hostname** must use a unique fully qualified domain name.
-        
+
     3.  Enter the **API Port** of the provider. The default port is
         `8443`.
 
@@ -73,10 +62,11 @@
     5.  Click **Validate** to confirm that {{ site.data.product.title_short }} can connect
         to the OpenShift Container Platform provider.
 
-9.  For the **Prometheus** alerts service, add the Prometheus alerts
-    endpoint in the **Alerts** tab:
+7.  In the **Alerts** endpoint tab optionally configure the alerts service:
 
-    1.  Select a **Security Protocol** method to specify how to
+    1.  Select a service type, or leave disabled.  Prometheus alerts are only supported on OCP v3
+
+    2.  Select a **Security Protocol** method to specify how to
         authenticate the service:
 
           - **SSL**: Authenticate the provider securely using a trusted
@@ -93,19 +83,20 @@
           - **SSL without validation**: Authenticate the provider
             insecurely using SSL. (Not recommended)
 
-    2.  Enter the **Hostname** (or IPv4 or IPv6 address) or alert
+    3.  Enter the **Hostname** (or IPv4 or IPv6 address) or alert
         **Route**.
 
-    3.  Enter the **API Port** if your Prometheus provider uses a
+    4.  Enter the **API Port** if your Prometheus provider uses a
         non-standard port for access. The default port is `443`.
 
-    4.  Click **Validate** to confirm that {{ site.data.product.title_short }} can
+    5.  Click **Validate** to confirm that {{ site.data.product.title_short }} can
         connect to the alerts service.
 
-10. If you selected a metrics service, configure the service details in
-    the **Metrics** tab:
+8. In the **Metrics** endpoint tab optionally configure the metrics service details:
 
-    1.  Select a **Security Protocol** method to specify how to
+    1.  Select a service type (Prometheus or Hawkular) or leave disabled
+
+    2.  Select a **Security Protocol** method to specify how to
         authenticate the service:
 
           - **SSL**: Authenticate the provider securely using a trusted
@@ -132,16 +123,39 @@
           - **SSL without validation**: Authenticate the provider
             insecurely using SSL. (Not recommended)
 
-    2.  Enter the **Hostname** (or IPv4 or IPv6 address) of the
-        provider, or use the **Detect** button to find the hostname.
+    3.  Enter the **Hostname** (or IPv4 or IPv6 address) of the
+        metrics service.
 
-    3.  Enter the **API Port** if your Hawkular or Prometheus provider
+        In order to find the hostname you can use the `oc get route` command.
+
+        On OCPv4 you can get the Prometheus route by running:
+
+        `oc get route prometheus-k8s -n openshift-monitoring`
+
+        Example:
+        ```
+        oc get route prometheus-k8s -n openshift-monitoring
+        NAME             HOST/PORT                                            PATH             SERVICES  PORT      TERMINATION          WILDCARD
+        prometheus-k8s   prometheus-k8s-openshift-monitoring.ocp.example.com  prometheus-k8s   web       reencrypt/Redirect   None
+        ```
+
+        In this example you would use `prometheus-k8s-openshift-monitoring.ocp.example.com` as the metrics hostname.
+
+        On OCPv3 you can get the Hawkular route by running:
+
+        `oc get route hawkular-metrics -n openshift-infra`
+
+        Or the Prometheus route:
+
+        `oc get route prometheus -n openshift-metrics`
+
+    4.  Enter the **API Port** if your Hawkular or Prometheus provider
         uses a non-standard port for access. The default port is `443`.
 
-    4.  Click **Validate** to confirm that {{ site.data.product.title_short }} can connect
+    5.  Click **Validate** to confirm that {{ site.data.product.title_short }} can connect
         to the metrics endpoint.
 
-11. Click the **Advanced** tab to add image inspector settings for
+9. Click the **Advanced** tab to add image inspector settings for
     scanning container images on your provider using OpenSCAP.
 
     **Note:**
@@ -172,7 +186,7 @@
     5.  Enter `https://www.redhat.com/security/data/metrics/ds/` in
         **CVE location**.
 
-12. Click **Add**.
+10. Click **Add**.
 
 **Note:**
 


### PR DESCRIPTION
The documentation needs to be updated after migrating the new container provider screen to DDF, specifically the "Detect" route button is no longer available so we should document what `oc` command to run in order to get the hostname.

Also we should indicate that Prometheus Alerts are not supported on OCPv4.

This is what the current dialogs look like:

Default Endpoint:
![Screenshot from 2021-04-27 12-49-50](https://user-images.githubusercontent.com/12851112/116281060-4f569600-a757-11eb-9107-985cd1f4a595.png)

Metrics:
![Screenshot from 2021-04-27 12-49-44](https://user-images.githubusercontent.com/12851112/116281039-4a91e200-a757-11eb-915b-47f816742dcb.png)

Alerts:
![Screenshot from 2021-04-27 12-49-47](https://user-images.githubusercontent.com/12851112/116281050-4d8cd280-a757-11eb-9fc5-1ee512ef3444.png)

