### PR TITLE
Reorganize capabilities matrix to include the list of providers up front

### DIFF
--- a/capabilities_matrix/_topics/automation_providers.md
+++ b/capabilities_matrix/_topics/automation_providers.md
@@ -2,10 +2,10 @@
 
 The following table outlines the capabilities of {{ site.data.product.title_short }} that are known to work for various automation providers.
 
-| Feature                        | Ansible Tower | Embedded Ansible | Automate Engine |
-| ------------------------------ | ------------- | ---------------- | --------------- |
-| Groups Inventory               | ✅            | ❌               | ❌              |
-| Configured Systems Inventory   | ✅            | ❌               | ❌              |
-| Job Template Inventory         | ✅            | ❌               | ❌              |
-| Integrate with Service Catalog | ✅            | ✅               | ✅              |
-| Automate Workflows             | ✅            | ✅               | ✅              |
+| Feature                        | Ansible Tower / AWX | Embedded Ansible | Automate Engine |
+| ------------------------------ | ------------------- | ---------------- | --------------- |
+| Groups Inventory               | ✅                  | ❌               | ❌              |
+| Configured Systems Inventory   | ✅                  | ❌               | ❌              |
+| Job Template Inventory         | ✅                  | ❌               | ❌              |
+| Integrate with Service Catalog | ✅                  | ✅               | ✅              |
+| Automate Workflows             | ✅                  | ✅               | ✅              |

--- a/capabilities_matrix/_topics/infrastructure_providers.md
+++ b/capabilities_matrix/_topics/infrastructure_providers.md
@@ -2,60 +2,60 @@
 
  The following tables outline the capabilities of {{ site.data.product.title_short }} that are known to work for various virtual infrastructure providers.
 
-| Discovery                                                    | VMware vSphere | Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
-| ------------------------------------------------------------ | -------------- | ---------------------------- | ------------------------------------------------------- | --------------------------------- |
-| Compute Inventory                                            | ✅             | ✅                           | ✅                                                      | ✅ (Nodes and Services)           |
-| Network Inventory                                            | ✅             | ✅ (OVN)                     | ❌                                                      | ❌                                |
-| Storage Inventory                                            | ✅             | ❌                           | ❌                                                      | ❌                                |
-| Events                                                       | ✅             | ✅                           | ✅                                                      | ✅                                |
-| Metrics                                                      | ✅             | ✅                           | ✅                                                      | ✅                                |
-| Forensic Analysis (SmartState)                               | ✅             | ✅                           | ❌                                                      | ✅ (Nodes)                        |
+| Discovery                                                    | VMware vSphere | oVirt / Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
+| ------------------------------------------------------------ | -------------- | ------------------------------------ | ------------------------------------------------------- | --------------------------------- |
+| Compute Inventory                                            | ✅             | ✅                                   | ✅                                                      | ✅ (Nodes and Services)           |
+| Network Inventory                                            | ✅             | ✅ (OVN)                             | ❌                                                      | ❌                                |
+| Storage Inventory                                            | ✅             | ❌                                   | ❌                                                      | ❌                                |
+| Events                                                       | ✅             | ✅                                   | ✅                                                      | ✅                                |
+| Metrics                                                      | ✅             | ✅                                   | ✅                                                      | ✅                                |
+| Forensic Analysis (SmartState)                               | ✅             | ✅                                   | ❌                                                      | ✅ (Nodes)                        |
 
-| General Features                                             | VMware vSphere | Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
-| ------------------------------------------------------------ | -------------- | ---------------------------- | ------------------------------------------------------- | --------------------------------- |
-| Relationship Discovery                                       | ✅             | ✅                           | ✅                                                      | ✅                                |
-| Drift Comparison                                             | ✅             | ✅                           | ✅                                                      | ✅ (Nodes)                        |
-| VM Genealogy                                                 | ✅             | ✅                           | ✅                                                      | ✅                                |
-| Capacity & Utilization                                       | ✅             | ✅                           | ❌                                                      | ✅                                |
-| VM Event Timelines                                           | ✅             | ✅                           | ✅                                                      | ❌                                |
-| Infrastructure Event Timelines                               | ❌             | ❌                           | ❌                                                      | ✅                                |
-| Reporting                                                    | ✅             | ✅                           | ✅                                                      | ✅                                |
-| Right Sizing                                                 | ✅             | ✅                           | ❌                                                      | ❌                                |
-| Chargeback                                                   | ✅             | ✅                           | ✅ (Allocation only)                                    | ❌                                |
-| Automation Work Flows                                        | ✅             | ✅                           | ✅                                                      | ❌                                |
-| Tag Mapping from Provider                                    | ❌             | ❌                           | ❌                                                      | ❌                                |
-| Tag Mapping to Provider                                      | ❌             | ❌                           | ❌                                                      | ❌                                |
-| VM Compliance Enforcement                                    | ✅             | ✅                           | ✅                                                      | ❌                                |
-| VM Policy Enforcement                                        | ✅             | ✅                           | ✅                                                      | ❌                                |
-| Alerts - Real Time                                           | ✅             | ❌                           | ❌                                                      | ❌                                |
-| Alerts - VM Value Changed                                    | ✅             | ✅                           | ❌                                                      | ❌                                |
-| Alerts - VM Reconfigured                                     | ✅             | ✅                           | ❌                                                      | ❌                                |
-| Integrate with Service Catalogs                              | ✅             | ✅                           | ✅                                                      | ❌                                |
+| General Features                                             | VMware vSphere | oVirt / Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
+| ------------------------------------------------------------ | -------------- | ------------------------------------ | ------------------------------------------------------- | --------------------------------- |
+| Relationship Discovery                                       | ✅             | ✅                                   | ✅                                                      | ✅                                |
+| Drift Comparison                                             | ✅             | ✅                                   | ✅                                                      | ✅ (Nodes)                        |
+| VM Genealogy                                                 | ✅             | ✅                                   | ✅                                                      | ✅                                |
+| Capacity & Utilization                                       | ✅             | ✅                                   | ❌                                                      | ✅                                |
+| VM Event Timelines                                           | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| Infrastructure Event Timelines                               | ❌             | ❌                                   | ❌                                                      | ✅                                |
+| Reporting                                                    | ✅             | ✅                                   | ✅                                                      | ✅                                |
+| Right Sizing                                                 | ✅             | ✅                                   | ❌                                                      | ❌                                |
+| Chargeback                                                   | ✅             | ✅                                   | ✅ (Allocation only)                                    | ❌                                |
+| Automation Work Flows                                        | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| Tag Mapping from Provider                                    | ❌             | ❌                                   | ❌                                                      | ❌                                |
+| Tag Mapping to Provider                                      | ❌             | ❌                                   | ❌                                                      | ❌                                |
+| VM Compliance Enforcement                                    | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| VM Policy Enforcement                                        | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| Alerts - Real Time                                           | ✅             | ❌                                   | ❌                                                      | ❌                                |
+| Alerts - VM Value Changed                                    | ✅             | ✅                                   | ❌                                                      | ❌                                |
+| Alerts - VM Reconfigured                                     | ✅             | ✅                                   | ❌                                                      | ❌                                |
+| Integrate with Service Catalogs                              | ✅             | ✅                                   | ✅                                                      | ❌                                |
 
-| Operations                                                   | VMware vSphere | Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
-| ------------------------------------------------------------ | -------------- | ---------------------------- | ------------------------------------------------------- | --------------------------------- |
-| VM Remote Console Access (see section below)                 | ✅             | ✅                           | ✅                                                      | ❌                                |
-| VM Power Operations                                          | ✅             | ✅                           | ✅                                                      | ❌                                |
-| VM Provisioning                                              |                |                              |                                                         |                                 |
-|   - using PXE                                                | ✅             | ✅                           | ❌                                                      | ❌                                |
-|   - using ISO                                                | ❌             | ✅                           | ❌                                                      | ❌                                |
-|   - from Template to VM                                      | ✅             | ✅                           | ✅                                                      | ❌                                |
-|   - from VM to Template                                      | ✅             | ✅                           | ❌                                                      | ❌                                |
-|   - Clone from VM to VM                                      | ✅             | ❌                           | ❌                                                      | ❌                                |
-|   - Sysprep Windows Templates                                | ✅             | ✅                           | ❌                                                      | ❌                                |
-|   - Cloud-init                                               | ❌             | ✅                           | ❌                                                      | ❌                                |
-| VM Retirement                                                | ✅             | ✅                           | ✅                                                      | ❌                                |
-| VM Reconfiguration                                           | ✅             | ✅                           | ❌                                                      | ❌                                |
-|   - Disk Addition                                            | ✅             | ✅                           | ❌                                                      | ❌                                |
-|   - Network Interface Add/Remove                             | ✅             | ✅                           | ❌                                                      | ❌                                |
-| VM Snapshot Creation and Removal                             | ✅             | ✅                           | ❌                                                      | ❌                                |
-| Host Power Operations                                        | ✅             | ❌                           | ❌                                                      | ✅                                |
-| Node Operations                                              |                |                              |                                                         |                                 |
-|   - Add/Remove Node                                          | ❌             | ❌                           | ❌                                                      | ✅                                |
-|   - Scale Down Node                                          | ❌             | ❌                           | ❌                                                      | ✅ (Compute nodes only)           |
-|   - Scale Up Nodes                                           | ❌             | ❌                           | ❌                                                      | ✅ (Compute nodes only)           |
-|   - Nodes Policy Enforcement                                 | ❌             | ❌                           | ❌                                                      | ✅                                |
-|   - Nodes Evacuate                                           | ❌             | ❌                           | ❌                                                      | ✅                                |
+| Operations                                                   | VMware vSphere | oVirt / Red Hat Virtualization (RHV) | Microsoft System Center Virtual Machine Manager (SCVMM) | OpenStack Platform (OSP) Director |
+| ------------------------------------------------------------ | -------------- | ------------------------------------ | ------------------------------------------------------- | --------------------------------- |
+| VM Remote Console Access (see section below)                 | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| VM Power Operations                                          | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| VM Provisioning                                              |                |                                      |                                                         |                                 |
+|   - using PXE                                                | ✅             | ✅                                   | ❌                                                      | ❌                                |
+|   - using ISO                                                | ❌             | ✅                                   | ❌                                                      | ❌                                |
+|   - from Template to VM                                      | ✅             | ✅                                   | ✅                                                      | ❌                                |
+|   - from VM to Template                                      | ✅             | ✅                                   | ❌                                                      | ❌                                |
+|   - Clone from VM to VM                                      | ✅             | ❌                                   | ❌                                                      | ❌                                |
+|   - Sysprep Windows Templates                                | ✅             | ✅                                   | ❌                                                      | ❌                                |
+|   - Cloud-init                                               | ❌             | ✅                                   | ❌                                                      | ❌                                |
+| VM Retirement                                                | ✅             | ✅                                   | ✅                                                      | ❌                                |
+| VM Reconfiguration                                           | ✅             | ✅                                   | ❌                                                      | ❌                                |
+|   - Disk Addition                                            | ✅             | ✅                                   | ❌                                                      | ❌                                |
+|   - Network Interface Add/Remove                             | ✅             | ✅                                   | ❌                                                      | ❌                                |
+| VM Snapshot Creation and Removal                             | ✅             | ✅                                   | ❌                                                      | ❌                                |
+| Host Power Operations                                        | ✅             | ❌                                   | ❌                                                      | ✅                                |
+| Node Operations                                              |                |                                      |                                                         |                                 |
+|   - Add/Remove Node                                          | ❌             | ❌                                   | ❌                                                      | ✅                                |
+|   - Scale Down Node                                          | ❌             | ❌                                   | ❌                                                      | ✅ (Compute nodes only)           |
+|   - Scale Up Nodes                                           | ❌             | ❌                                   | ❌                                                      | ✅ (Compute nodes only)           |
+|   - Nodes Policy Enforcement                                 | ❌             | ❌                                   | ❌                                                      | ✅                                |
+|   - Nodes Evacuate                                           | ❌             | ❌                                   | ❌                                                      | ✅                                |
 
 
 #### Remote Consoles

--- a/capabilities_matrix/_topics/providers.md
+++ b/capabilities_matrix/_topics/providers.md
@@ -1,0 +1,35 @@
+## Providers
+
+The following table lists providers that {{ site.data.product.title_short }} can manage.
+
+| Platform                                                                             |
+| --------                                                                             |
+| [Amazon Web Services (AWS) EC2](#cloud-providers)                                    |
+| [Amazon Web Services (AWS) EKS](#container-providers)                                |
+| [Ansible AWX](#automation-providers)                                                 |
+| Foreman                                                                              |
+| [Google Cloud Platform (GCP)](#cloud-providers)                                      |
+| IBM AutoSDE                                                                          |
+| [IBM Cloud (VPC)](#cloud-providers)                                                  |
+| IBM Power Systems Virtual Servers                                                    |
+| [IBM PowerVC](#cloud-providers) (via the OpenStack API)                              |
+| IBM Terraform                                                                        |
+| [Kubernetes](#container-providers)                                                   |
+| KubeVirt                                                                             |
+| Lenovo xClarity                                                                      |
+| [Microsoft Azure](#cloud-providers)                                                  |
+| [Microsoft Azure Stack](#cloud-providers)                                            |
+| [Microsoft System Center Virtual Machine Manager (SCVMM)](#infrastructure-providers) |
+| [Nuage Networks](#network-providers)                                                 |
+| [OpenShift Container Platform (OCP)](#container-providers)                           |
+| [OpenStack](#cloud-providers)                                                        |
+| [Oracle Cloud](#cloud-providers)                                                     |
+| [oVirt](#infrastructure-providers)                                                   |
+| [Red Hat Ansible Tower](#automation-providers)                                       |
+| [Red Hat OpenStack Platform (OSP)](#cloud-providers)                                 |
+| Red Hat Satellite                                                                    |
+| [Red Hat Virtualization (RHV)](#infrastructure-providers)                            |
+| Redfish                                                                              |
+| [VMware vCloud](#cloud-providers)                                                    |
+| [VMware vSphere](#infrastructure-providers)                                          |
+| [VMware NSX-t](#network-providers)                                                   |

--- a/capabilities_matrix/_topics/runtime_platforms.md
+++ b/capabilities_matrix/_topics/runtime_platforms.md
@@ -1,15 +1,21 @@
 ## Runtime Platforms
 
-The following table lists platforms on which {{ site.data.product.title_short }} can be installed and run from.
+The following table lists platforms on which {{ site.data.product.title_short }} can be installed and run from. They can be obtained from the [downloads page](/download/).
 
-| Platform                                                     | Appliance or Podified |
+| Platform                                                     | Form Factor          |
 | ------------------------------------------------------------ | -------------------- |
 | Amazon Web Services (AWS)                                    | Appliance            |
-| Microsoft Azure                                              | Appliance            |
+| Docker                                                       | Monolithic Container |
 | Google Cloud Platform (GCP)                                  | Appliance            |
-| Microsoft System Center Virtual Machine Manager (SCVMM)      | Appliance            |
+| IBM Cloud                                                    | Appliance            |
 | Kubernetes                                                   | Podified             |
+| libvirt                                                      | Appliance            |
+| Microsoft Azure                                              | Appliance            |
+| Microsoft System Center Virtual Machine Manager (SCVMM)      | Appliance            |
 | OpenShift Container Platform (OCP)                           | Podified             |
-| Red Hat OpenStack Platform (OSP)                             | Appliance            |
+| OpenStack                                                    | Appliance            |
+| oVirt                                                        | Appliance            |
+| QEmu/KVM                                                     | Appliance            |
 | Red Hat Virtualization (RHV)                                 | Appliance            |
+| Vagrant                                                      | Appliance            |
 | VMware vSphere                                               | Appliance            |

--- a/capabilities_matrix/index.md
+++ b/capabilities_matrix/index.md
@@ -3,12 +3,15 @@
 
 # Capabilities Matrix
 
-{% include_relative _topics/browsers.md %}
+## Platforms and Browsers
+
+{% include_relative _topics/providers.md %}
 
 {% include_relative _topics/runtime_platforms.md %}
 
+{% include_relative _topics/browsers.md %}
 
-## Capabilities
+## Provider Capabilities
 
 {{ site.data.product.title_short }} allows you to discover and interact with various providers.  What follows are the capabilities available in various areas for the providers under management.
 


### PR DESCRIPTION
@chessbyte @agrare Please review.

Nobody cares about browsers, which was first, so I moved that later on, instead putting the providers themselves first, followed by the runtime platforms.  The providers link to their section within the document, so since we don't have some sections they don't link, which I think is ok for now.