### PR TITLE
Remove OpenStack reference from PowerVC

### DIFF
--- a/capabilities_matrix/_topics/providers.md
+++ b/capabilities_matrix/_topics/providers.md
@@ -12,7 +12,7 @@ The following table lists providers that {{ site.data.product.title_short }} can
 | IBM AutoSDE                                                                          |
 | [IBM Cloud VPC](#cloud-providers)                                                    |
 | [IBM Power Systems Virtual Servers (PowerVS)](#cloud-providers)                      |
-| [IBM PowerVC](#cloud-providers) (via the OpenStack API)                              |
+| [IBM PowerVC](#cloud-providers)                                                      |
 | IBM Terraform                                                                        |
 | [Kubernetes](#container-providers)                                                   |
 | KubeVirt                                                                             |


### PR DESCRIPTION
There is now a standalone PowerVC provider:
https://github.com/ManageIQ/manageiq-providers-ibm_power_vc

The new PowerVC provider is a subclass of the OpenStack provider. Though
it does still use the OpenStack API this is now transparent to the user.