### PR TITLE
[WIP] Rename service evmserverd to manageiq

### DIFF
--- a/appliance_hardening_guide/_topics/db_ssl.md
+++ b/appliance_hardening_guide/_topics/db_ssl.md
@@ -23,9 +23,9 @@ To configure SSL on the database appliance:
 
 1.  Log in as `root` to the appliance where the database resides.
 
-2.  Stop the `evmserverd` and `postgresql` services:
+2.  Stop the `manageiq` and `postgresql` services:
 
-        [root@appliance2 ~]# systemctl stop evmserverd
+        [root@appliance2 ~]# systemctl stop manageiq
         [root@appliance2 ~]# systemctl stop postgresql.service
 
 3.  Install the server key file in the correct location and set the ownership and permissions for it:
@@ -74,10 +74,10 @@ To configure SSL on the database appliance:
 
     This changes the incoming communication protocol to use SSL and refuse any unencrypted PostgreSQL connections.
 
-9.  Start the `postgresql` and `evmserverd` services so that the changes take effect:
+9.  Start the `postgresql` and `manageiq` services so that the changes take effect:
 
         [root@{{ site.data.product.title_short_l }}1 ~]# systemctl start postgresql.service
-        [root@{{ site.data.product.title_short_l }}1 ~]# systemctl start evmserverd
+        [root@{{ site.data.product.title_short_l }}1 ~]# systemctl start manageiq
 
 The database appliance now accepts only connections from connecting appliances that use SSL. The following procedure sets up connecting appliances to communicate to the database by using SSL. Use this procedure for each connecting appliance:
 

--- a/appliance_hardening_guide/_topics/keys.md
+++ b/appliance_hardening_guide/_topics/keys.md
@@ -74,7 +74,7 @@ and run the following commands replacing `dbpassword` with your database
 password:
 
     [root@{productname_short_l} ~]# fix_auth --databaseyml --hostname localhost --password dbpassword
-    [root@{productname_short_l} ~]# systemctl restart evmserverd
+    [root@{productname_short_l} ~]# systemctl restart manageiq
 
 This completes the new encryption key generation for your
 {{ site.data.product.title_short }} infrastructure.

--- a/appliance_hardening_guide/_topics/ssl_certs.md
+++ b/appliance_hardening_guide/_topics/ssl_certs.md
@@ -69,7 +69,7 @@ Copy the certificate and key files to the certificate directory on the appliance
 
 After the certificate and key files have been copied, restart the appliance:
 
-    [root@ ~]# systemctl restart evmserverd
+    [root@ ~]# systemctl restart manageiq
 
 The appliance now uses your own certificate.
 

--- a/general_configuration/_topics/configuration.md
+++ b/general_configuration/_topics/configuration.md
@@ -2999,7 +2999,7 @@ restoring data.
 
 3.  Stop both the EVM and PostgreSQL servers:
 
-        # systemctl stop evmserverd
+        # systemctl stop manageiq
         # systemctl stop $APPLIANCE_PG_SERVICE
 
 4.  Rename the existing data directory:
@@ -3022,7 +3022,7 @@ restoring data.
 8.  Restart the PostgreSQL and EVM servers:
 
         # systemctl start $APPLIANCE_PG_SERVICE
-        # systemctl start evmserverd
+        # systemctl start manageiq
 
 #### Running Database Garbage Collection
 
@@ -3063,7 +3063,7 @@ PostgreSQL database.
 
 To change the password, you need to stop the {{ site.data.product.title_short }}
 service, change the password for the PostgreSQL database, run a command
-to change the password in the configuration file that `evmserverd` uses
+to change the password in the configuration file that `manageiq` uses
 to access the server, and restart the {{ site.data.product.title_short }} appliance.
 
 1.  Stop the {{ site.data.product.title_short }} service:
@@ -3073,7 +3073,7 @@ to access the server, and restart the {{ site.data.product.title_short }} applia
     2.  To stop the {{ site.data.product.title_short }} service, run the following
         command:
 
-            service evmserverd stop
+            service manageiq stop
 
 2.  Use `pgadmin` to change the password for your {{ site.data.product.title_short }}
     database (default is `vmdb_production`). If you do not have
@@ -3091,14 +3091,14 @@ to access the server, and restart the {{ site.data.product.title_short }} applia
         \q
         ```
 
-3.  Change the password in the configuration file that `evmserverd` uses
+3.  Change the password in the configuration file that `manageiq` uses
     to access the server:
 
         /var/www/miq/vmdb/tools/fix_auth.rb --databaseyml --password newpassword
 
 4.  Restart the {{ site.data.product.title_short }} service:
 
-        service evmserverd start
+        service manageiq start
 
 5.  Verify that you can log in to the {{ site.data.product.title_short }} console.
 
@@ -3111,16 +3111,16 @@ to access the server, and restart the {{ site.data.product.title_short }} applia
     2.  To stop the {{ site.data.product.title_short }} service, run the following
         command:
 
-            service evmserverd stop
+            service manageiq stop
 
-2.  Change the password in the configuration file that `evmserverd` uses
+2.  Change the password in the configuration file that `manageiq` uses
     to access the server:
 
         /var/www/miq/vmdb/tools/fix_auth.rb --databaseyml --password newpassword
 
 3.  Restart the {{ site.data.product.title_short }} service:
 
-        service evmserverd start
+        service manageiq start
 
     <div class="important">
 
@@ -3159,13 +3159,13 @@ to access the server, and restart the {{ site.data.product.title_short }} applia
     3.  Save the new **database.yml**.
 
 5.  Run the following command to change the password in the
-    configuration file that `evmserverd` uses to access the server:
+    configuration file that `manageiq` uses to access the server:
 
         /var/www/miq/vmdb/tools/fix_auth.rb --databaseyml --password newpassword
 
 6.  Restart the new worker appliance:
 
-        service evmserverd restart
+        service manageiq restart
 
 #### Creating a Database Dump
 

--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -39,7 +39,7 @@ the non-database {{ site.data.product.title_short }} appliances.
     For standard {{ site.data.product.title_short }} installations, a pre-sized database disk is already attached, initialized, encryption key generated, database configured with a region, and the application started.
 
     2. Select **Stop evm server processes**, select `y`.
-    3. Quit from appliance console and `run systemctl disable evmserverd` to make this a standalone database server.
+    3. Quit from appliance console and `run systemctl disable manageiq` to make this a standalone database server.
 
     Alternatively, if you attached a new database disk and have not yet configured the application:
 
@@ -58,7 +58,7 @@ the non-database {{ site.data.product.title_short }} appliances.
     6.  For **Should this appliance run as a standalone database
         server?**, select `y`. Selecting this option configures this
         appliance as a database-only appliance, and therefore the
-        {{ site.data.product.title_abbr_uc }} application and `evmserverd` processes
+        {{ site.data.product.title_abbr_uc }} application and `manageiq` processes
         will not run. This is required in highly available database
         deployments.
 

--- a/high_availability_guide/_topics/overview.md
+++ b/high_availability_guide/_topics/overview.md
@@ -1,12 +1,12 @@
 ## Environment Overview
 
-Learn how to configure and manage database high availability in a {{ site.data.product.title_short }} environment. This configuration allows for disaster mitigation: a failure in the primary database does not result in downtime, as the standby database takes over the failed database’s processes. This is made possible by database replication between two or more database servers. In {{ site.data.product.title_short }}, these servers are *database-only {{ site.data.product.title_short }} appliances*, which do not have `evmserverd` processes that are enabled. This is configured from the `appliance_console` menu at the time of deployment.
+Learn how to configure and manage database high availability in a {{ site.data.product.title_short }} environment. This configuration allows for disaster mitigation: a failure in the primary database does not result in downtime, as the standby database takes over the failed database’s processes. This is made possible by database replication between two or more database servers. In {{ site.data.product.title_short }}, these servers are *database-only {{ site.data.product.title_short }} appliances*, which do not have `manageiq` processes that are enabled. This is configured from the `appliance_console` menu at the time of deployment.
 
 Two types of appliances that are used in high availability:
 
-  - *Database-only {{ site.data.product.title_short }} appliances*, which do not have `evmserverd` processes that are enabled or a user interface.
+  - *Database-only {{ site.data.product.title_short }} appliances*, which do not have `manageiq` processes that are enabled or a user interface.
 
-  - *Non-database {{ site.data.product.title_short }} appliances*, which are standard appliances that contain a user interface and which have `evmserverd` processes that are enabled.
+  - *Non-database {{ site.data.product.title_short }} appliances*, which are standard appliances that contain a user interface and which have `manageiq` processes that are enabled.
 
 In this configuration, a failover monitor daemon is configured and running on each non-database {{ site.data.product.title_short }} appliance. The failover monitor watches the `repmgr` metadata about the database-only appliances present in the cluster. When the primary database-only appliance goes down, the non-database {{ site.data.product.title_short }} appliances start polling each of the configured standby database-only appliances to monitor which one comes up as the new primary. The promotion is orchestrated either by `repmgrd` on the database-only appliances or is done manually. When the non-database {{ site.data.product.title_short }} appliances find that a standby has been promoted, {{ site.data.product.title_short }} reconfigures the setup by writing the new IP address in the `database.yml` file to point to the new primary.
 

--- a/high_availability_guide/_topics/renaming_ha_appliances.md
+++ b/high_availability_guide/_topics/renaming_ha_appliances.md
@@ -33,10 +33,10 @@ following:
 
         # systemctl stop postgresql.service
 
-4.  Stop `evmserverd` on each non-database {{ site.data.product.title_short }}
+4.  Stop `manageiq` on each non-database {{ site.data.product.title_short }}
     appliance:
 
-        # systemctl stop evmserverd
+        # systemctl stop manageiq
 
 ### Updating the Primary Database-Only Appliance Hostname
 
@@ -172,19 +172,19 @@ Repeat these steps on any additional standby database-only appliances.
 <div class="important">
 
 If you are using non-dedicated database appliances, also stop
-`evmserverd` on those appliances before changing their hostnames, and
+`manageiq` on those appliances before changing their hostnames, and
 reconfigure `database.yml` before restarting.
 
 </div>
 
 #### Restarting Services
 
-1.  Start `evmserverd` on each non-database {{ site.data.product.title_short }}
+1.  Start `manageiq` on each non-database {{ site.data.product.title_short }}
     appliance:
 
-        # systemctl start evmserverd
+        # systemctl start manageiq
 
-    After `evmserverd` has started successfully, all appliances will be
+    After `manageiq` has started successfully, all appliances will be
     able connect to the database.
 
 2.  Restart the failover monitor on the non-database

--- a/high_availability_guide/_topics/updating_ha.md
+++ b/high_availability_guide/_topics/updating_ha.md
@@ -60,9 +60,9 @@ while some steps apply to all appliances.
 4.  Start each database-only appliance.
 
 5.  Start each non-database {{ site.data.product.title_short }} appliance again, and
-    stop `evmserverd` on each just after boot:
+    stop `manageiq` on each just after boot:
 
-        # systemctl stop evmserverd
+        # systemctl stop manageiq
 
 6.  Apply updates by running the following on each appliance:
 

--- a/managing_providers/_topics/automation_management_providers.md
+++ b/managing_providers/_topics/automation_management_providers.md
@@ -68,7 +68,7 @@ default. Enable this server role to utilize Ansible Automation Inside.
 **Note:**
 
 Configure your {{ site.data.product.title_short }} appliance network identity (hostname/IP address) before enabling the Embedded Ansible server role.
-Restart the `evmserverd` service on the appliance with the enabled Embedded Ansible server role after making any changes to the hostname or IP address.
+Restart the `manageiq` service on the appliance with the enabled Embedded Ansible server role after making any changes to the hostname or IP address.
 
 1.  Browse to the settings menu, then **Configuration** →
     **Settings**.


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/21397

We are keeping an alias so old commands still work, but updating documentation to reference new process name.