### PR TITLE
PowerVS and PowerVC capability matrix updates

### DIFF
--- a/capabilities_matrix/_topics/cloud_providers.md
+++ b/capabilities_matrix/_topics/cloud_providers.md
@@ -10,7 +10,7 @@ The following tables outline the capabilities of {{ site.data.product.title_shor
 |   - Cloud Networks             | ✅  | ✅    | ✅  | ✅        | ✅      | ✅      | ✅     | ✅    |
 |   - Cloud Subnets              | ✅  | ✅    | ✅  | ✅        | ✅      | ✅      | ✅     | ✅    |
 |   - Floating IP Addresses      | ✅  | ✅    | ✅  | ✅        | N/A     | N/A     | ✅     | ❌    |
-|   - Load Balancers             | ✅  | ✅    | ✅  | ❌        | N/A     | ❌      | ✅     | ❌    |
+|   - Load Balancers             | ✅  | ✅    | ✅  | ❌        | N/A     | N/A     | ✅     | ❌    |
 |   - Network Managers           | ❌  | ✅    | ✅  | ❌        | ❌      | ✅      | ✅     | ✅    |
 |   - Network Manager Relations  | ✅  | ✅    | ✅  | ✅        | ❌      | ✅      | ✅     | ✅    |
 |   - Network Ports              | ✅  | ✅    | ✅  | ✅        | ❌      | ✅      | ✅     | ✅    |

--- a/capabilities_matrix/_topics/cloud_providers.md
+++ b/capabilities_matrix/_topics/cloud_providers.md
@@ -17,7 +17,7 @@ The following tables outline the capabilities of {{ site.data.product.title_shor
 |   - Network Routers            | ❌  | ❌    | ✅  | ✅        | ❌      | ❌      | ✅     | ❌    |
 |   - Security Groups            | ✅  | ✅    | ✅  | ✅        | N/A     | N/A     | N/A     | ❌    |
 | Storage Inventory              | ✅  | ✅    | ✅  | ✅        | ✅      | ✅      | ✅     | ✅    |
-|   - Storage Manager            | ✅  | ❌    | ❌  | ✅        | ❌      | ✅      | ✅     | ❌    |
+|   - Storage Manager            | ✅  | ❌    | ❌  | ✅        | ✅      | ✅      | ✅     | ❌    |
 |   - Volumes                    | ❌  | ❌    | ✅  | ✅        | ✅      | ✅      | ✅     | ✅    |
 | Events                         | ✅  | ✅    | ✅  | ✅        | ✅      | ❌      | ✅     | ✅    |
 | Metrics                        | ✅  | ✅    | ✅  | ✅        | ❌      | ❌      | ❌     | ✅    |


### PR DESCRIPTION
I missed an update in #1563 - PowerVC storage manager (cinder) should be ✅ 

I also noticed that the PowerVS Load Balancer capabilty should be "N/A" instead of "X".