### PR TITLE
Fix PowerVC capability matrix entry for Sysprep

### DIFF
--- a/capabilities_matrix/_topics/cloud_providers.md
+++ b/capabilities_matrix/_topics/cloud_providers.md
@@ -54,7 +54,7 @@ The following tables outline the capabilities of {{ site.data.product.title_shor
 |   - from Volume Snapshot to Instance   | ❌  | ❌    | ❌  | ✅        | ❌                               | ❌       | ❌      | ❌           |
 |   - from Orchestration Template        | ✅  | ✅    | ❌  | ✅        | ❌                               | ❌       | ❌      | ❌           |
 |   - Cloud-init                         | ❌  | ❌    | ❌  | ✅        | ✅                               | ✅       | ❌      | ❌           |
-|   - Sysprep Windows Templates          | ❌  | ❌    | ❌  | ✅        | ❌                               | N/A      | N/A     | ❌           |
+|   - Sysprep Windows Templates          | ❌  | ❌    | ❌  | ✅        | N/A                              | N/A      | N/A     | ❌           |
 | Instance Retirement                    | ✅  | ✅    | ✅  | ✅        | ✅                               | ✅       | ❌      | ✅           |
 | Instance Reconfiguration               | ❌  | ❌    | ❌  | ✅        | ✅                               | ❌       | ❌      | ❌           |
 |   - Disk Addition                      | ✅  | ✅    | ❌  | ✅        | ❌                               | ✅       | ❌      | ❌           |


### PR DESCRIPTION
Windows on Power is N/A - replacing the :x: with "N/A" to show feature cannot be implemented.