### PR TITLE
Use OS certificate bundle

### DIFF
--- a/appliance_hardening_guide/_topics/db_ssl.md
+++ b/appliance_hardening_guide/_topics/db_ssl.md
@@ -10,14 +10,12 @@ The appliance image ships with a default SSL certificate and it is recommended t
 
 For more information, see [Generating SSL Certificates for Your Appliance and Database](#generating-ssl-certificates-for-your-appliance-and-database).
 
-
   - `/var/www/miq/vmdb/certs/server.cer` - Signed or self-signed certificate for the database appliance.
-
   - `/var/www/miq/vmdb/certs/server.cer.key` - Private key for server certificate.
 
-  - `/var/www/miq/vmdb/certs/root.crt` - The root CA certificate used to sign the CA certificate for the {{ site.data.product.title_short }} database. You can either use a self-signed certificate or a certificate that is signed by a trusted CA to generate your root certificate.
-
 It is also recommended to stop all {{ site.data.product.title_short }} services before configuring the database to use SSL.
+
+#### Configure SSL on the database appliance
 
 To configure SSL on the database appliance:
 
@@ -25,44 +23,30 @@ To configure SSL on the database appliance:
 
 2.  Stop the `evmserverd` and `postgresql` services:
 
-        [root@appliance2 ~]# systemctl stop evmserverd
-        [root@appliance2 ~]# systemctl stop postgresql.service
+        $ systemctl stop evmserverd
+        $ systemctl stop postgresql.service
 
 3.  Install the server key file in the correct location and set the ownership and permissions for it:
 
-        [root@appliance2 ~]# install -m 600 -o postgres -g postgres \
-        /var/www/miq/vmdb/certs/server.cer.key /var/www/miq/vmdb/certs/postgres.key
+        $ install -m 600 -o postgres -g postgres \
+        /var/www/miq/vmdb/certs/server.cer.key /var/lib/pgsql/data/postgres.key
 
 4.  Install the server certificate file in the correct location and set the ownership and permissions for it:
 
-        [root@appliance2 ~]# install -m 644 -o postgres -g postgres \
-        /var/www/miq/vmdb/certs/server.cer /var/www/miq/vmdb/certs/postgres.crt
+        $ install -m 644 -o postgres -g postgres \
+        /var/www/miq/vmdb/certs/server.cer /var/lib/pgsql/data/postgres.crt
 
-5.  Install the database appliance certificate file as the root certificate in the correct location and set the ownership and
-    permissions for it.
-
-    If you are using a self-signed certificate, run:
-
-        [root@appliance2 ~]# install -m 644 -o postgres -g postgres /var/www/miq/vmdb/certs/server.cer /var/www/miq/vmdb/certs/root.crt
-
-    If you are using a third-party certificate, edit this command to install your root certificate.
-
-6.  Make sure that the security context is set correctly for the files in `/var/www/miq/certs`:
-
-        [root@appliance2 ~]# restorecon -R -v /var/www/miq/vmdb/certs
-
-7.  Open the `/var/lib/pgsql/data/postgresql.conf` file and uncomment and edit the `ssl` option:
+5.  Open the `/var/lib/pgsql/data/postgresql.conf` file and uncomment and edit the `ssl` option:
 
         ssl=on
 
-    In the same file, locate the options `ssl_cert_file`, `ssl_key_file`, and `ssl_ca_file` that specify the location of SSL
+    In the same file, locate the options `ssl_cert_file` and `ssl_key_file` that specify the location of SSL
     certificates and edit them so that they are uncommented and point to the correct certificate files:
 
-        ssl_cert_file = '/var/www/miq/vmdb/certs/postgres.crt'  # (change requires restart)
-        ssl_key_file  = '/var/www/miq/vmdb/certs/postgres.key'  # (change requires restart)
-        ssl_ca_file   = '/var/www/miq/vmdb/certs/root.crt'      # (change requires restart)
+        ssl_cert_file = 'postgres.crt'  # (change requires restart)
+        ssl_key_file  = 'postgres.key'  # (change requires restart)
 
-8.  Open the `/var/lib/pgsql/data/pg_hba.conf` file and locate the two lines that contain:
+6.  Open the `/var/lib/pgsql/data/pg_hba.conf` file and locate the two lines that contain:
 
         host      all      all   all           md5
         #hostssl  all      all   all           md5
@@ -74,30 +58,34 @@ To configure SSL on the database appliance:
 
     This changes the incoming communication protocol to use SSL and refuse any unencrypted PostgreSQL connections.
 
-9.  Start the `postgresql` and `evmserverd` services so that the changes take effect:
+7.  Start the `postgresql` and `evmserverd` services so that the changes take effect:
 
-        [root@{{ site.data.product.title_short_l }}1 ~]# systemctl start postgresql.service
-        [root@{{ site.data.product.title_short_l }}1 ~]# systemctl start evmserverd
+        $ systemctl start postgresql.service
+        $ systemctl start evmserverd
+
+#### Configure SSL on all connected appliances
 
 The database appliance now accepts only connections from connecting appliances that use SSL. The following procedure sets up connecting appliances to communicate to the database by using SSL. Use this procedure for each connecting appliance:
 
 1.  Log in as `root` to the connecting appliance.
 
-2.  Create the `.postgresql` directory in your `root` user home directory.
+2.  Copy the root certificate file from the database to the operating system's list of valid certificates:
 
-        [root@{{ site.data.product.title_short_l }}2 ~]# mkdir /root/.postgresql
-
-    The PostgreSQL client library, which {{ site.data.product.title_short }} also uses, looks to this directory for custom configuration files.
-
-3.  Copy the root certificate file from the database appliance to the `/root/.postgresql` directory on the connecting appliance:
-
-        [root@{{ site.data.product.title_short_l }}2 ~]# scp root@[database_appliance_fqdn]:/var/www/miq/vmdb/certs/root.crt /root/.postgresql/root.crt
+        $ DATABASE=[database_appliance_fqdn]
+        $ scp root@${DATABASE}:/var/www/miq/vmdb/certs/root.crt /etc/pki/ca-trust/source/anchors/${DATABASE}-postgres
+        $ update-ca-trust extract
+        $ export PGSSLROOTCERT=/etc/pki/tls/certs/ca-bundle.crt
 
     Where `[database_appliance_fqdn]` is the fully qualified domain name of the database appliance.
 
+3.  Test the certificate got added to the certificate database:
+
+        $ openssl x509 -in /etc/pki/tls/certs/ca-bundle.crt -text -noout
+
 4.  Test the connection between the connecting appliance and the database appliance by using the `psql`command:
 
-        [root@localhost ~]# psql -h [database_appliance_fqdn] -d vmdb_production
+        $ PGSSLMODE=verify-full psql -h [database_appliance_fqdn] -d vmdb_production \
+          -c "SELECT * from pg_stat_ssl WHERE pid=pg_backend_pid()"
         Password: ********
         psql (9.2.8)
         SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
@@ -106,6 +94,17 @@ The database appliance now accepts only connections from connecting appliances t
         vmdb_production=#
 
     The `psql` displays information about the SSL connection, which indicates that the configuration succeeded. Enter `\q` to leave `psql`.
+    The `PGSSLMODE` variable forces a certain level of SSL. To learn more, please see [postgress sslmode documentation].
+
+    [postgress sslmode documentation]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE
+ 
+5.  Ensure `/etc/default/manageiq.properties` has the proper ssl key file location defined:
+
+        $ grep PGSSLROOTCERT /etc/default/manageiq.properties || \
+        echo PGSSLROOTCERT=/etc/pki/tls/certs/ca-bundle.crt >> /etc/default/manageiq.properties
+
+    The standard `manageiq.properties` should already have the `PGSSLROOTCERT` defined.
+    The above command adds an entry to `manageiq.properties` if it is not already present.
 
 Complete this procedure for each external appliance. This enhances the security of all database transactions in your {{ site.data.product.title_short }} infrastructure.
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq-appliance/pull/341

This gets database ssl keys out of `/root`, which is only accessible to `root` user, and into a standard location which is accessible to other users, namely user `manageiq`

1. Store the key that signed the postgres server in the standard location
2. No longer store `root.crt` in `/root` so user manageiq can use it
3. Still configure postgres for public and private key
4. No longer store `postgres.key` in /var/vmdb/ since `postgres` can not access those files.
5. No longer configure postgres with a root cert that verifies the cert of the connecting client. This is typically `ssl_ca_file=root.crt`. We only use server side certificates and not client side certificates.
