### PR TITLE
Move providers under type sections in left-size nav

### DIFF
--- a/_data/site_menu.yml
+++ b/_data/site_menu.yml
@@ -74,90 +74,103 @@ administration:
         - title: Overview
           path: "/docs/reference/latest/managing_providers/index.html"
           desc: "Managing your infrastructure, cloud, and containers providers and datastores"
+        - title: Infrastructure Providers
+          children:
+          - title: Red Hat Virtualization Providers
+            path: "/docs/reference/latest/managing_providers/infrastructure_providers/red_hat_virtualization_providers.html"
+            desc: "Managing Red Hat Virtualization Providers"
 
-        - title: Red Hat Virtualization Providers
-          path: "/docs/reference/latest/managing_providers/infrastructure_providers/red_hat_virtualization_providers.html"
-          desc: "Managing Red Hat Virtualization Providers"
+          - title: OpenStack Infrastructure Providers
+            path: "/docs/reference/latest/managing_providers/infrastructure_providers/openstack_infrastructure_providers.html"
+            desc: "Managing OpenStack Infrastructure Providers"
 
-        - title: OpenStack Infrastructure Providers
-          path: "/docs/reference/latest/managing_providers/infrastructure_providers/openstack_infrastructure_providers.html"
-          desc: "Managing OpenStack Infrastructure Providers"
+          - title: VMware vCenter Providers
+            path: "/docs/reference/latest/managing_providers/infrastructure_providers/vmware_vcenter_providers.html"
+            desc: "Managing VMware vCenter Providers"
 
-        - title: VMware vCenter Providers
-          path: "/docs/reference/latest/managing_providers/infrastructure_providers/vmware_vcenter_providers.html"
-          desc: "Managing VMware vCenter Providers"
+          - title: Microsoft SCVMM Providers
+            path: "/docs/reference/latest/managing_providers/infrastructure_providers/microsoft_scvmm_providers.html"
+            desc: "Managing Microsoft SCVMM Providers"
 
-        - title: Microsoft SCVMM Providers
-          path: "/docs/reference/latest/managing_providers/infrastructure_providers/microsoft_scvmm_providers.html"
-          desc: "Managing Microsoft SCVMM Providers"
+        - title: Configuration Providers
+          children:
+          - title: IBM Terraform Providers
+            path: "/docs/reference/latest/managing_providers/configuration_management_providers/ibm_terraform_provider.html"
+            desc: "Managing IBM Terraform Providers"
 
-        - title: IBM Terraform Providers
-          path: "/docs/reference/latest/managing_providers/configuration_management_providers/ibm_terraform_provider.html"
-          desc: "Managing IBM Terraform Providers"
+          - title: Red Hat Satellite 6 Providers
+            path: "/docs/reference/latest/managing_providers/configuration_management_providers/red_hat_satellite_6.html"
+            desc: "Managing Red Hat Satellite 6 Providers"
 
-        - title: Red Hat Satellite 6 Providers
-          path: "/docs/reference/latest/managing_providers/configuration_management_providers/red_hat_satellite_6.html"
-          desc: "Managing Red Hat Satellite 6 Providers"
+        - title: Cloud Providers
+          children:
+          - title: Azure Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/azure_providers.html"
+            desc: "Managing Azure Providers"
 
-        - title: Azure Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/azure_providers.html"
-          desc: "Managing Azure Providers"
+          - title: Amazon EC2 Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/amazon_ec2_providers.html"
+            desc: "Managing Amazon EC2 Providers"
 
-        - title: Amazon EC2 Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/amazon_ec2_providers.html"
-          desc: "Managing Amazon EC2 Providers"
+          - title: Google Compute Engine Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/google_compute_engine_providers.html"
+            desc: "Managing Google Compute Engine Providers"
 
-        - title: Google Compute Engine Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/google_compute_engine_providers.html"
-          desc: "Managing Google Compute Engine Providers"
+          - title: IBM Cloud VPC Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_cloud_vpc_providers.html"
+            desc: "Managing IBM Cloud VPC Providers"
 
-        - title: IBM Cloud VPC Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_cloud_vpc_providers.html"
-          desc: "Managing IBM Cloud VPC Providers"
+          - title: IBM Power Systems Virtual Servers Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_power_systems_virtual_servers_providers.html"
+            desc: "Managing IBM Power Systems Virtual Servers Providers"
 
-        - title: IBM Power Systems Virtual Servers Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_power_systems_virtual_servers_providers.html"
-          desc: "Managing IBM Power Systems Virtual Servers Providers"
+          - title: IBM PowerVC Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_power_vc_providers.html"
+            desc: "Managing IBM PowerVC Providers"
 
-        - title: IBM PowerVC Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/ibm_power_vc_providers.html"
-          desc: "Managing IBM PowerVC Providers"
+          - title: OpenStack Providers
+            path: "/docs/reference/latest/managing_providers/cloud_providers/openstack_providers.html"
+            desc: "Managing OpenStack Providers"
 
-        - title: OpenStack Providers
-          path: "/docs/reference/latest/managing_providers/cloud_providers/openstack_providers.html"
-          desc: "Managing OpenStack Providers"
+        - title: Container Providers
+          children:
+          - title: Azure Kubernetes Providers
+            path: "/docs/reference/latest/managing_providers/container_providers/azure_kubernetes_providers.html"
+            desc: "Managing Azure Kubernetes Providers"
 
-        - title: Azure Kubernetes Providers
-          path: "/docs/reference/latest/managing_providers/container_providers/azure_kubernetes_providers.html"
-          desc: "Managing Azure Kubernetes Providers"
+          - title: Red Hat OpenShift Providers
+            path: "/docs/reference/latest/managing_providers/container_providers/red_hat_openshift_providers.html"
+            desc: "Managing Red Hat OpenShift Providers"
 
-        - title: Red Hat OpenShift Providers
-          path: "/docs/reference/latest/managing_providers/container_providers/red_hat_openshift_providers.html"
-          desc: "Managing Red Hat OpenShift Providers"
+          - title: IBM Cloud Kubernetes Service Providers
+            path: "/docs/reference/latest/managing_providers/container_providers/ibm_cloud_kubernetes_service_providers.html"
+            desc: "Managing IBM Cloud Kubernetes Service Providers"
 
-        - title: IBM Cloud Kubernetes Service Providers
-          path: "/docs/reference/latest/managing_providers/container_providers/ibm_cloud_kubernetes_service_providers.html"
-          desc: "Managing IBM Cloud Kubernetes Service Providers"
+          - title: Oracle Kubernetes Engine Providers
+            path: "/docs/reference/latest/managing_providers/container_providers/oracle_kubernetes_engine_providers.html"
+            desc: "Managing Oracle Kubernetes Engine Providers"
 
-        - title: Oracle Kubernetes Engine Providers
-          path: "/docs/reference/latest/managing_providers/container_providers/oracle_kubernetes_engine_providers.html"
-          desc: "Managing Oracle Kubernetes Engine Providers"
+          - title: VMware Tanzu Providers
+            path: "/docs/reference/latest/managing_providers/container_providers/vmware_tanzu_providers.html"
+            desc: "Managing VMware Tanzu Providers"
 
-        - title: VMware Tanzu Providers
-          path: "/docs/reference/latest/managing_providers/container_providers/vmware_tanzu_providers.html"
-          desc: "Managing VMware Tanzu Providers"
+        - title: Storage Providers
+          children:
+          - title: Amazon Elastic Block Store Providers
+            path: "/docs/reference/latest/managing_providers/storage_providers/amazon_ebs_managers.html"
+            desc: "Managing Amazon Elastic Block Store Providers"
 
-        - title: Amazon Elastic Block Store Providers
-          path: "/docs/reference/latest/managing_providers/storage_providers/amazon_ebs_managers.html"
-          desc: "Managing Amazon Elastic Block Store Providers"
+          - title: OpenStack Block Storage Providers
+            path: "/docs/reference/latest/managing_providers/storage_providers/openstack_block_storage_managers.html"
+            desc: "Managing OpenStack Block Storage Providers"
 
-        - title: OpenStack Block Storage Providers
-          path: "/docs/reference/latest/managing_providers/storage_providers/openstack_block_storage_managers.html"
-          desc: "Managing OpenStack Block Storage Providers"
+          - title: OpenStack Object Storage Providers
+            path: "/docs/reference/latest/managing_providers/storage_providers/openstack_object_storage_managers.html"
+            desc: "Managing OpenStack Object Storage Providers"
 
-        - title: OpenStack Object Storage Providers
-          path: "/docs/reference/latest/managing_providers/storage_providers/openstack_object_storage_managers.html"
-          desc: "Managing OpenStack Object Storage Providers"
+          - title: IBM Cloud Object Storage Providers
+            path: "/docs/reference/latest/managing_providers/storage_providers/ibm_cloud_object_storage_managers.html"
+            desc: "Managing IBM Cloud Object Storage Providers"
 
     - title: Provisioning Virtual Machines and Hosts
       path: "/docs/reference/latest/provisioning_virtual_machines_and_hosts/index.html"


### PR DESCRIPTION
Nest e.g. infra_managers under `Administration/Managing Providers/Infrastructure Providers`
rather than them all being under one big section