### PR TITLE
Remove incorrect note about disabled providers

### DIFF
--- a/managing_providers/cloud_providers/_topics/disabling_amazon_cloud_regions.md
+++ b/managing_providers/cloud_providers/_topics/disabling_amazon_cloud_regions.md
@@ -25,9 +25,3 @@ available when adding an Amazon EC2 provider.
           - ap-northeast-1
 
 6.  Click **Save**.
-
-**Note:**
-
-In AWS, Government regions are disabled by default. To enable a disabled
-region, be sure to do so in the `production.yml` configuration file
-manually.


### PR DESCRIPTION
@agrare Please review.

~~Alternatively, should we remove this section or reword it?  It's meant for downstream cases where the permissions file is present, but we don't have one upstream.~~ EDIT: Removing the section entirely, because it's wrong...see discussion