### PR TITLE
Appliances no longer initialize on first boot

### DIFF
--- a/high_availability_guide/_topics/installation.md
+++ b/high_availability_guide/_topics/installation.md
@@ -36,13 +36,6 @@ the non-database {{ site.data.product.title_short }} appliances.
 
     1.  Configure the hostname by selecting **Set Hostname**.
 
-    For standard {{ site.data.product.title_short }} installations, a pre-sized database disk is already attached, initialized, encryption key generated, database configured with a region, and the application started.
-
-    2. Select **Stop evm server processes**, select `y`.
-    3. Quit from appliance console and `run systemctl disable evmserverd` to make this a standalone database server.
-
-    Alternatively, if you attached a new database disk and have not yet configured the application:
-
     2.  Select **Configure Application**.
 
     3.  Select **Create key** to create the encryption key. You can


### PR DESCRIPTION
We now always assume the user has attached an unpartitioned database disk and we have to configure the application in the appliance_console.

As of the following PRs, we do not initialize the application on first boot: 

https://github.com/ManageIQ/manageiq-appliance-build/pull/511
https://github.com/ManageIQ/manageiq-appliance/pull/359