### PR TITLE
Drop OCPv3 from the documentation

### DIFF
--- a/_includes/provider-ocp-add-container.md
+++ b/_includes/provider-ocp-add-container.md
@@ -45,7 +45,7 @@
         The **Hostname** must use a unique fully qualified domain name.
 
     3.  Enter the **API Port** of the provider. The default port is
-        `8443`.
+        `6443`.
 
     4.  Enter a token for your provider in the **Token** box.
 
@@ -61,36 +61,6 @@
 
     5.  Click **Validate** to confirm that {{ site.data.product.title_short }} can connect
         to the OpenShift Container Platform provider.
-
-7.  In the **Alerts** endpoint tab optionally configure the alerts service:
-
-    1.  Select a service type, or leave disabled.  Prometheus alerts are only supported on OCP v3
-
-    2.  Select a **Security Protocol** method to specify how to
-        authenticate the service:
-
-          - **SSL**: Authenticate the provider securely using a trusted
-            Certificate Authority. Select this option if the provider
-            has a valid SSL certificate and it is signed by a trusted
-            Certificate Authority. No further configuration is required
-            for this option.
-
-          - **SSL trusting custom CA**: Authenticate the provider with a
-            self-signed certificate. For this option, copy your
-            provider’s CA certificate to the **Trusted CA
-            Certificates** box in PEM format.
-
-          - **SSL without validation**: Authenticate the provider
-            insecurely using SSL. (Not recommended)
-
-    3.  Enter the **Hostname** (or IPv4 or IPv6 address) or alert
-        **Route**.
-
-    4.  Enter the **API Port** if your Prometheus provider uses a
-        non-standard port for access. The default port is `443`.
-
-    5.  Click **Validate** to confirm that {{ site.data.product.title_short }} can
-        connect to the alerts service.
 
 8. In the **Metrics** endpoint tab optionally configure the metrics service details:
 
@@ -128,7 +98,7 @@
 
         In order to find the hostname you can use the `oc get route` command.
 
-        On OCPv4 you can get the Prometheus route by running:
+        You can retrieve the Prometheus route by running:
 
         `oc get route prometheus-k8s -n openshift-monitoring`
 
@@ -140,14 +110,6 @@
         ```
 
         In this example you would use `prometheus-k8s-openshift-monitoring.ocp.example.com` as the metrics hostname.
-
-        On OCPv3 you can get the Hawkular route by running:
-
-        `oc get route hawkular-metrics -n openshift-infra`
-
-        Or the Prometheus route:
-
-        `oc get route prometheus -n openshift-metrics`
 
     4.  Enter the **API Port** if your Hawkular or Prometheus provider
         uses a non-standard port for access. The default port is `443`.

--- a/capabilities_matrix/_topics/container_providers.md
+++ b/capabilities_matrix/_topics/container_providers.md
@@ -2,27 +2,27 @@
 
 The following table outlines the capabilities of {{ site.data.product.title_short }} for various container providers.
 
-| Feature                                 | OpenShift 3.11 | OpenShift 4.x | Kubernetes | Amazon EKS           | Google GKE | Azure AKS | Oracle OKE | IBM Cloud IKS | VMware Tanzu |
-| --------------------------------------- | -------------- |-------------- | ---------- | -------------------- | ---------- | --------- | ---------- | ------------- | ------------ |
-| Relationship Discovery                  | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Track Container Image Relationship      | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Capacity & Utilization                  | ✅             | ✅            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| Capture Container Event Timelines       | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Reporting                               | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Chargeback by Allocation                | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Chargeback by Usage                     | ✅             | ✅            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| Remote Cockpit Node Access              | ✅             | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| Container Node Compliance Enforcement   | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Container Node Policy Enforcement       | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Replicator Compliance Enforcement       | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Replicator Policy Enforcement           | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Pod Compliance Enforcement              | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Pod Policy Enforcement                  | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Image Compliance Enforcement            | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Image Policy Enforcement                | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Template Provisioning                   | ✅             | ❌            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| Smart State                             | ✅             | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| OpenSCAP Execution and Report           | ✅             | ❌            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
-| Cross Linking Underlying Infrastructure | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Tag Mapping from Provider               | ✅             | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
-| Tag Mapping to Provider                 | ❌             | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Feature                                 |  OpenShift 4.x | Kubernetes | Amazon EKS           | Google GKE | Azure AKS | Oracle OKE | IBM Cloud IKS | VMware Tanzu |
+| --------------------------------------- | -------------- | ---------- | -------------------- | ---------- | --------- | ---------- | ------------- | ------------ |
+| Relationship Discovery                  | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Track Container Image Relationship      | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Capacity & Utilization                  | ✅            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Capture Container Event Timelines       | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Reporting                               | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Chargeback by Allocation                | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Chargeback by Usage                     | ✅            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Remote Cockpit Node Access              | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Container Node Compliance Enforcement   | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Container Node Policy Enforcement       | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Replicator Compliance Enforcement       | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Replicator Policy Enforcement           | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Pod Compliance Enforcement              | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Pod Policy Enforcement                  | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Image Compliance Enforcement            | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Image Policy Enforcement                | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Template Provisioning                   | ❌            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Smart State                             | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| OpenSCAP Execution and Report           | ❌            | ✅         | ❌                   |❌          |❌         |❌          |❌             |❌             |
+| Cross Linking Underlying Infrastructure | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Tag Mapping from Provider               | ✅            | ✅         | ✅                   |✅          |✅         |✅          |✅             |✅             |
+| Tag Mapping to Provider                 | ❌            | ❌         | ❌                   |❌          |❌         |❌          |❌             |❌             |

--- a/integration_with_openshift_container_platform/_topics/prerequisites.md
+++ b/integration_with_openshift_container_platform/_topics/prerequisites.md
@@ -2,6 +2,6 @@ This guide assumes that you have:
 
   - [Already deployed {{ site.data.product.title_short }} on your chosen platform](https://www.ibm.com/support/knowledgecenter/SSFC4F_2.0.0/mcm/infrastructure/infra_mgmt_intro.html)
 
-  - [Already deployed OpenShift Container Platform](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/installation_and_configuration/)
+  - [Already deployed OpenShift Container Platform](https://access.redhat.com/documentation/en-us/openshift_container_platform/)
 
 When enabling metrics on OpenShift Container Platform, you can store your metrics data on *persistent* or *non-persistent* storage. To use persistent storage, you need to provision a persistent volume specifically for this purpose before [configuring the metrics components](#ocp-metrics-storage). See [Persistent Volumes](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/architecture/additional-concepts#architecture-additional-concepts-storage) in the OpenShift Container Platform *Architecture* documentation for more information.


### PR DESCRIPTION
Drop the obvious OCPv3 mentions in the docs.  There are some other sections which have to be reviewed for accuracy as I suspect they are not accurate for OCPv4 (mainly https://github.com/ManageIQ/manageiq-documentation/blob/c663fae30c18c506ca70e957bbb4d55036ba714a/integration_with_openshift_container_platform/_topics/ocp-metrics.md and the various https://github.com/ManageIQ/manageiq-documentation/blob/c663fae30c18c506ca70e957bbb4d55036ba714a/_includes/provider-ocp-mgt-token.md )