### PR TITLE
Add documentation for Kafka keystores

### DIFF
--- a/installing_on_kubernetes/_topics/pods_ssl.md
+++ b/installing_on_kubernetes/_topics/pods_ssl.md
@@ -8,8 +8,9 @@ The certificates should all be signed by a CA and that CA certificate should be 
       --from-file=root_crt=./certs/root.crt \
       --from-file=httpd_crt=./certs/httpd.crt \
       --from-file=httpd_key=./certs/httpd.key \
-      --from-file=kafka_crt=./certs/kafka.crt \
-      --from-file=kafka_key=./certs/kafka.key \
+      --from-file=kafka_truststore=<path>/kafka.truststore.jks \
+      --from-file=kafka_keystore=<path>/kafka.keystore.jks \
+      --from-literal=kafka_keystore_pass=<keystore-password> \
       --from-file=memcached_crt=./certs/memcached.crt \
       --from-file=memcached_key=./certs/memcached.key \
       --from-file=postgresql_crt=./certs/postgresql.crt \
@@ -25,3 +26,17 @@ The certificates should all be signed by a CA and that CA certificate should be 
 ### Generating certificates:
 We need a CA and certificates for each service.  The certificates need to be valid for the internal kubernetes service name (i.e. httpd, postgres, etc.) and the services that are backing the route (ui & api) also need the certificate to include a SAN with the application domain name.  For example, the certificate for the UI needs to be valid for the hostname `ui` and also `your_application.apps.example.com`.
 If you want a script that will generate these certificates for you, see: https://github.com/ManageIQ/manageiq-pods/blob/master/tools/cert_generator.rb
+
+### Generating Kafka certificate stores:
+In order to enable TLS for Kafka, Java KeyStore files (`.jks`) containing the CA (i.e. `root_crt`) will need to be provided alongside the password for the keystores. The keystores should following naming conventions `kafka.truststore.jks` and `kafka.keystore.jks` as well as use the same password for both. If you want a script to generate the keystores for you, see: https://github.com/ManageIQ/manageiq-pods/blob/master/tools/keystore_generator.sh
+
+**Note:** If using the script, you will need to provide the paths to your CA certificate and key (`root.crt` and `root.key` if using `cert_generator.rb`) as well as the keystore password of your choice.
+```sh
+manageiq-pods % ./tools/keystore_generator.sh
+Enter CA cert path:
+./tools/certs/root.crt
+Enter CA key path:
+./tools/certs/root.key
+Set Keystore password:
+******
+```


### PR DESCRIPTION
- added documentation outlining steps to create keystores for Kafka and how to integrate them with `internal-certificates-secret` in order to use SSL with Kafka

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/955

Needed for:
- https://github.com/ManageIQ/manageiq-pods/pull/951

Ref:
- https://github.com/ManageIQ/manageiq-pods/issues/789

@miq-bot assign @bdunne
@miq-bot add_reviewer @Fryguy
@miq-bot add_label enhancement