### PR TITLE
Add root key to internal certificate secret example

### DIFF
--- a/installing_on_kubernetes/_topics/pods_ssl.md
+++ b/installing_on_kubernetes/_topics/pods_ssl.md
@@ -6,6 +6,7 @@ The certificates should all be signed by a CA and that CA certificate should be 
 ```sh
     oc create secret generic internal-certificates-secret \
       --from-file=root_crt=./certs/root.crt \
+      --from-file=root_key=./certs/root.key \
       --from-file=httpd_crt=./certs/httpd.crt \
       --from-file=httpd_key=./certs/httpd.key \
       --from-file=kafka_crt=./certs/kafka.crt \


### PR DESCRIPTION
- the root key is needed for downstream Kafka SSL configuration, see https://strimzi.io/docs/operators/in-development/deploying.html#installing-your-own-ca-certificates-str

@miq-bot assign @bdunne 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_label enhancement