### PR TITLE
Add manageiq user as allowed uid to the sssd.conf documentation

### DIFF
--- a/auth/active_directory.md
+++ b/auth/active_directory.md
@@ -110,7 +110,7 @@ include *domainname* for these attributes.
 
 =>  [ifp]
 =>  default_domain_suffix = example.com
-=>  allowed_uids = apache, root
+=>  allowed_uids = apache, root, manageiq
 =>  user_attributes = +mail, +givenname, +sn, +displayname, +domainname
 ```
 

--- a/auth/ldap.md
+++ b/auth/ldap.md
@@ -197,7 +197,7 @@ include *domainname* for these attributes.
 
     =>  [ifp]
     =>  default_domain_suffix = example.com
-    =>  allowed_uids = apache, root
+    =>  allowed_uids = apache, root, manageiq
     =>  user_attributes = +mail, +givenname, +sn, +displayname, +domainname
 
 #### Testing SSSD Updates


### PR DESCRIPTION
When we moved to using a manageiq user, we need to add this user so it has permission in sssd.conf.