### PR TITLE
pg_log changed to log in postgres 10 as default log directory

### DIFF
--- a/_includes/example-postgresql-config-file.md
+++ b/_includes/example-postgresql-config-file.md
@@ -295,7 +295,7 @@
 
     # These are only used if logging_collector is on:
     log_directory = '/www/postgres/log' # Customer specific setting
-    #log_directory = 'pg_log'       # directory where log files are written,
+    #log_directory = 'log'       # directory where log files are written,
                         # can be absolute or relative to PGDATA
     log_filename = 'postgresql-%Y-%m-%d.log'        # log file name pattern,
                         # can include strftime() escapes

--- a/general_configuration/_topics/configuration.md
+++ b/general_configuration/_topics/configuration.md
@@ -1211,7 +1211,7 @@ Table: collection
 <p>log/*.txt</p>
 <p>config/*</p>
 <p>/var/lib/pgsql/data/*.conf</p>
-<p>/var/lib/pgsql/data/pg_log/*</p>
+<p>/var/lib/pgsql/data/log/*</p>
 <p>/var/log/syslog*</p>
 <p>/var/log/daemon.log*</p>
 <p>/etc/default/ntp*</p>


### PR DESCRIPTION
https://www.postgresql.org/docs/9.6/runtime-config-logging.html

log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is pg_log.

vs.

https://www.postgresql.org/docs/10/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHERE log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is log.

It remains the same in postgresql 13.

See also:
https://github.com/ManageIQ/manageiq/pull/22747
https://github.com/ManageIQ/manageiq-appliance/pull/377