### PR TITLE
Fix appliance backup and restore numbered lists

### DIFF
--- a/appliances/backup_and_restore.md
+++ b/appliances/backup_and_restore.md
@@ -5,9 +5,9 @@
 Creating a backup of the appliance will be done using SSH or the console.
 
 1. Launch `appliance_console`
-  a. Select `Stop EVM Server Processes` to stop the server processes
-  b. Select `Create Database Backup` and choose a backup location (/tmp/evm_db.backup is the default)
-  c. Select `Quit` to return to the shell
+   1. Select `Stop EVM Server Processes` to stop the server processes
+   2. Select `Create Database Backup` and choose a backup location (/tmp/evm_db.backup is the default)
+   3. Select `Quit` to return to the shell
 2. For convenience, create a TGZ containing all files required to restore the database
    ```bash
      tar -czvf /root/backup.tgz /tmp/evm_db.backup /var/www/miq/vmdb/GUID /var/www/miq/vmdb/certs/v2_key
@@ -43,18 +43,17 @@ Restoring a backup of the appliance will be done using SSH or the console.
      tar -zxf /backup
      rm -f /backup # if desired to save space
    ```
-
 3. Launch `appliance_console`
-  a. If this is a brand new appliance and the database has not yet been initialized, select `Configure Application`. If this is an existing database appliance, this step can be skipped.
-    1. When prompted to configure the database, select `Create Internal Database`
-    2. When prompted to configure messaging, select `Make No messaging changes`
-    3. Choose a database disk
-    4. Answer y or n to "Should this appliance run as a standalone database server?"
-    5. Enter a region number (0), this is not important and will be overwritten on restore
-    6. Set a database password
-    7. Wait for database initialization to complete.
-  b. Select `Stop EVM Server Processes`
-  c. Select `Restore Database From Backup`
-    1. Decide whether you want to delete the backup file in /tmp after restore. (Yes)
-  d. Select `Start EVM Server Processes`
+   1. If this is a brand new appliance and the database has not yet been initialized, select `Configure Application`. If this is an existing database appliance, this step can be skipped.
+      1. When prompted to configure the database, select `Create Internal Database`
+      2. When prompted to configure messaging, select `Make No messaging changes`
+      3. Choose a database disk
+      4. Answer y or n to "Should this appliance run as a standalone database server?"
+      5. Enter a region number (0), this is not important and will be overwritten on restore
+      6. Set a database password
+      7. Wait for database initialization to complete.
+   2. Select `Stop EVM Server Processes`
+   3. Select `Restore Database From Backup`
+      - Decide whether you want to delete the backup file in /tmp after restore. (Yes)
+   4. Select `Start EVM Server Processes`
 4. After a few minutes, you can log into the web UI and see all of the data contained in the backup.


### PR DESCRIPTION
a/b/c are not valid Markdown. Also, need at least 3 spaces for nested items in numbered lists.

@rwellon @bdunne Please review.

Before:
![Preview_backup_and_restore_md_—_manageiq-documentation](https://github.com/ManageIQ/manageiq-documentation/assets/52120/6fe42ae7-ce98-4e92-82de-1d84f92f7c09)

After:
![Preview_backup_and_restore_md_—_manageiq-documentation](https://github.com/ManageIQ/manageiq-documentation/assets/52120/b6cfe2ba-41b6-4704-b6e1-97c3924f9761)
