### PR TITLE
Add `Q35 Chipset with BIOS` to RHV installation docs

### DIFF
--- a/installing_on_red_hat_virtualization/_topics/installation.md
+++ b/installing_on_red_hat_virtualization/_topics/installation.md
@@ -109,7 +109,8 @@ for the database:
     Virtual Machine** dialog.
 
 2.  From the **General** tab, specify a name for the virtual machine and
-    any other details.
+    any other details.  Ensure that `Q35 Chipset with BIOS` is selected
+    for **Chipset/Firmware Type**.
 
 3.  Click **Attach**.
 


### PR DESCRIPTION
Newer versions of RHV/Ovirt now default to `Q35 Chipset with UEFI` which will not boot with our ovirt qcow2 disk image since it does not have an EFI partition.

![image](https://github.com/ManageIQ/manageiq-documentation/assets/12851112/2f6287b8-2abf-4ec0-a585-175589e579ae)
