### PR TITLE
It is not required to stop services before backup

### DIFF
--- a/appliances/backup_and_restore.md
+++ b/appliances/backup_and_restore.md
@@ -5,9 +5,8 @@
 Creating a backup of the appliance will be done using SSH or the console.
 
 1. Launch `appliance_console`
-   1. Select `Stop EVM Server Processes` to stop the server processes
-   2. Select `Create Database Backup` and choose a backup location (/tmp/evm_db.backup is the default)
-   3. Select `Quit` to return to the shell
+   1. Select `Create Database Backup` and choose a backup location (/tmp/evm_db.backup is the default)
+   2. Select `Quit` to return to the shell
 2. For convenience, create a TGZ containing all files required to restore the database
    ```bash
      tar -czvf /root/backup.tgz /tmp/evm_db.backup /var/www/miq/vmdb/GUID /var/www/miq/vmdb/certs/v2_key


### PR DESCRIPTION
pg_basebackup docs even describe taking online backups and even concurrent backups. Perhaps this was a requirement at one time but is no longer needed.

https://www.postgresql.org/docs/13/app-pgbasebackup.html

https://www.postgresql.org/docs/13/app-pgdump.html