### PR TITLE
Messaging required when upgrading to quinteros

### DIFF
--- a/appliances/upgrading.md
+++ b/appliances/upgrading.md
@@ -31,6 +31,8 @@ In this example, we will update from jansa to kasparov.
         # reboot
 
 
+**Note:** If upgrading to Quinteros, messaging (Kafka) setup is required. See [Configure Messaging](../_includes/configuration.md#configure-messaging)
+
 # Appendix
 
 ## RPM URLs for manageiq-release


### PR DESCRIPTION
Since Kafka will be required, users that are upgrading will need to configure messaging via appliance_console

@miq-bot assign @agrare 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_label enhancement, quinteros/yes?

