### PR TITLE
Update openshift provider ClusterRole API instructions

### DIFF
--- a/_includes/provider-ocp-mgt-token.md
+++ b/_includes/provider-ocp-mgt-token.md
@@ -2,7 +2,7 @@ Run the following to obtain the token needed to add a Red Hat OpenShift provider
 
 1.  Obtain the `management` service account token name:
 
-        # oc describe sa -n management-infra management-admin
+        # oc describe sa -n $project_name $service_account_name
         ...
         Tokens:  management-admin-token-0f3fh
                  management-admin-token-q7a87
@@ -11,7 +11,7 @@ Run the following to obtain the token needed to add a Red Hat OpenShift provider
     output, replacing `management-admin-token-0f3fh` with the name of
     your token:
 
-        # oc describe secret -n management-infra management-admin-token-0f3fh
+        # oc describe secret -n $project_name management-admin-token-0f3fh
         ...
         Data
         ====

--- a/managing_providers/containers_providers/red_hat_openshift_providers.md
+++ b/managing_providers/containers_providers/red_hat_openshift_providers.md
@@ -21,7 +21,7 @@ First you have to create a service-account with the proper permissions for {{ si
 
 3. Create the cluster role
    ```
-   echo '{"apiVersion": "v1", "kind": "ClusterRole", "metadata": {"name": "management-manageiq-admin"}, "rules": [{"resources": ["pods/proxy"], "verbs": ["*"]}]}' | oc create -f -
+   echo '{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRole", "metadata": {"name": "management-manageiq-admin"}, "rules": [{"resources": ["pods/proxy"], "verbs": ["*"]}]}' | oc create -f -
    ```
 
 4. Apply roles and policies to the service account


### PR DESCRIPTION
The ClusterRole object is in the `authorization.openshift.io/v1` api group not the "core" `v1` api group.

https://docs.openshift.com/container-platform/4.14/rest_api/role_apis/clusterrole-authorization-openshift-io-v1.html#clusterrole-authorization-openshift-io-v1