### PR TITLE
Messaging configuration hostname guidelines

### DIFF
--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -54,6 +54,8 @@ Configuring messaging is required for appliance setup. It is recommended to conf
 2. Select **Proceed** and appliance_console will apply the configuration that you have
    requested then restart evmserverd to pick up the changes.
 
+**Note:** It is recommended to use your FQDN as the messaging hostname rather than `localhost`
+
 ### Configuring a Worker Appliance
 
 You can use multiple appliances to facilitate horizontal scaling, as

--- a/installing_on_aws/index.md
+++ b/installing_on_aws/index.md
@@ -7,6 +7,8 @@
 
 {% include configuration.md %}
 
+**Note:** When configuring messaging, please refer to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html on hostname guidelines i.e. inclusion of `.ec2.internal` or `.compute.internal` in the hostname
+
 {% include initial-login.md %}
 
 # Appendix


### PR DESCRIPTION
- AWS has a specific naming convention for their hostname which can be missed by users setting up an AWS appliance
- recommendation to not use localhost as the messaging hostname

@miq-bot add_label enhancement, quinteros/yes?
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @jrafanie, @agrare 