### PR TITLE
Revert #1780 and specify adding hostname to /etc/hosts

### DIFF
--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -54,7 +54,7 @@ Configuring messaging is required for appliance setup. It is recommended to conf
 2. Select **Proceed** and appliance_console will apply the configuration that you have
    requested then restart evmserverd to pick up the changes.
 
-**Note:** It is recommended to use your Fully Qualified Domain Name (FQDN) as the messaging hostname rather than `localhost`
+**Note:** It is recommended to use your Fully Qualified Domain Name (FQDN) as the messaging hostname rather than `localhost`, ensure that a resolvable and reachable non-localhost name entry is present in `/etc/hosts`
 
 ### Configuring a Worker Appliance
 

--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -54,7 +54,7 @@ Configuring messaging is required for appliance setup. It is recommended to conf
 2. Select **Proceed** and appliance_console will apply the configuration that you have
    requested then restart evmserverd to pick up the changes.
 
-**Note:** It is recommended to use your internal Fully Qualified Domain Name (FQDN) as the messaging hostname rather than `localhost`
+**Note:** It is recommended to use your Fully Qualified Domain Name (FQDN) as the messaging hostname rather than `localhost`
 
 ### Configuring a Worker Appliance
 


### PR DESCRIPTION
- Reverting https://github.com/ManageIQ/manageiq-documentation/pull/1780, I was under the impression that the "internal" note was meant for all appliances but it is specific to AWS and so it needs to be removed
- add suggestion for users to add a non-localhost name to `etc/hosts`

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @agrare, @jrafanie 
@miq-bot add_label enhancement, quinteros/yes