### PR TITLE
LVM guidelines for ISCSI/FC SmartState Analysis

### DIFF
--- a/managing_infrastructure_and_inventory/_topics/storage_support_notes_about_analyzing_from_rhevm_3.0.md
+++ b/managing_infrastructure_and_inventory/_topics/storage_support_notes_about_analyzing_from_rhevm_3.0.md
@@ -44,3 +44,21 @@ storage. NFS storage does not have these requirements.
 
     3.  Select the server that relates to this instance of the
         {{ site.data.product.title_short }} appliance.
+
+3.  If your storage domain is using Logical Volume Manager (LVM), you will need to manually activate your volume groups
+    and logical volumes before performing the SmartState Analysis.
+
+    1. Edit the `/etc/lvm/lvm.conf` file on the appliance and add volume groups to activate as read-only:
+        ```
+        activation {
+            read_only_volume_list = ["volume_group_0", "volume_group_1", etc...]
+        }
+        ```
+        Note: the volume group names are the storage domain UUIDs
+    
+    2. Activate volume groups:
+        ```
+        vgchange -ay
+        ```
+
+    For more information, please refer to the Red Hat Enterprise Linux documentation.

--- a/managing_infrastructure_and_inventory/_topics/storage_support_notes_about_analyzing_from_rhevm_3.1.md
+++ b/managing_infrastructure_and_inventory/_topics/storage_support_notes_about_analyzing_from_rhevm_3.1.md
@@ -24,6 +24,22 @@ Red Hat Enterprise Virtualization Manager 3.1 and above.
       - A {{ site.data.product.title_short }} appliance **must** reside in each datacenter
         with the iSCSI / FCP storage type.
 
+      - If your storage domain is using Logical Volume Manager (LVM), you will need to manually activate your volume groups
+        and logical volumes before performing the SmartState Analysis.
+
+        1. Edit the `/etc/lvm/lvm.conf` file on the appliance and add volume groups to activate as read-only:
+            ```
+            activation {
+                read_only_volume_list = ["volume_group_0", "volume_group_1", etc...]
+            }
+            ```
+            Note: the volume group names are the storage domain UUIDs
+        
+        2. Activate volume groups:
+            ```
+            vgchange -ay
+            ```
+
   - Other Notes
 
       - The **Edit Management Engine Relationship** option enables the


### PR DESCRIPTION
A user brought this to our attention about how in the case of inactive LVs, smartstate scan fails (which is to be expected). We are not able to activate LVs programatically because the `manageiq` user runs as non-root and so this is a technical limitation. As a result, I have documented the steps to advise on activating LVs before running a scan.

@miq-bot add_reviewer @agrare 
@miq-bot assign @agrare 
@miq-bot add_labels enhancement, radjabov/yes?