### PR TITLE
Update adding disabling cloud provider regions

### DIFF
--- a/managing_providers/cloud_providers/_topics/adding_amazon_cloud_regions.md
+++ b/managing_providers/cloud_providers/_topics/adding_amazon_cloud_regions.md
@@ -5,9 +5,11 @@ the appliance server. You can use this capability to add new regions that have b
 set up since {{ site.data.product.title_short }} was released.  Once adding the region it will be
 available when creating a new Amazon EC2 provider.
 
-1.  Click ![config gear](../../images/config-gear.png) (**Configuration**).
+1.  Click ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
 
-2.  Click on the **Settings** accordion, then click **ManageIQ Region** at the top.
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the additional
+    region to that server only.
 
 3.  Click on the **Advanced** tab.
 

--- a/managing_providers/cloud_providers/_topics/adding_azure_cloud_regions.md
+++ b/managing_providers/cloud_providers/_topics/adding_azure_cloud_regions.md
@@ -5,9 +5,12 @@ the appliance server. You can use this capability to add new regions that have b
 set up since {{ site.data.product.title_short }} was released.  Once added the region it will be available when
 creating a new Azure provider.
 
-1.  Click ![config gear](../../images/config-gear.png) (**Configuration**).
 
-2.  Click on the **Settings** accordion, then click **ManageIQ Region** at the top.
+1.  Click ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
+
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the additional
+    region to that server only.
 
 3.  Click on the **Advanced** tab.
 

--- a/managing_providers/cloud_providers/_topics/adding_ibm_cloud_vpc_regions.md
+++ b/managing_providers/cloud_providers/_topics/adding_ibm_cloud_vpc_regions.md
@@ -1,0 +1,33 @@
+## Adding IBM Cloud VPC Regions
+
+{{ site.data.product.title_short }} allows administrators to add additional IBM
+Cloud VPC regions on the appliance server. You can use this capability to add
+new regions that have been set up since {{ site.data.product.title_short }} was
+released. Once added the region it will be available when creating a new IBM
+Cloud VPC provider.
+
+1.  Browse to ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
+
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the additional
+    region to that server only.
+
+3.  Click on the **Advanced** tab.
+
+4.  Search for `:ems_ibm_cloud_vpc:`, and enter the regions you want to add
+    under `:additional_regions:`.
+
+        Example. To add hypothetical `lunar-base-1` `lunar-base-2` regions:
+
+        :ems_ibm_cloud_vpc:
+          :additional_regions:
+            :lunar-base-1:
+              :name: Lunar Base 1
+              :hostname: lunar-base-1.iaas.cloud.ibm.com
+              :description: Lunar Base 1
+            :lunar-base-2:
+              :name: Lunar Base 2
+              :hostname: lunar-base-2.iaas.cloud.ibm.com
+              :description: Lunar Base 2
+
+5.  Click **Save**.

--- a/managing_providers/cloud_providers/_topics/adding_ibm_power_systems_virtual_servers_regions.md
+++ b/managing_providers/cloud_providers/_topics/adding_ibm_power_systems_virtual_servers_regions.md
@@ -1,0 +1,33 @@
+## Adding IBM Power Systems Virtual Server Regions
+
+{{ site.data.product.title_short }} allows administrators to add additional IBM
+Power Systems Virtual Server regions on the appliance server. You can use this
+capability to add new regions that have been set up since
+{{ site.data.product.title_short }} was released. Once added the region it will
+be available when creating a new IBM Power Systems Virtual Server provider.
+
+1.  Browse to ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
+
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the additional
+    region to that server only.
+
+3.  Click on the **Advanced** tab.
+
+4.  Search for `:ems_ibm_cloud_power_virtual_servers:`, and enter the regions you want to add
+    under `:additional_regions:`.
+
+        Example. To add hypothetical `lunar-base-1` `lunar-base-2` regions:
+
+        :ems_ibm_cloud_power_virtual_servers:
+          :additional_regions:
+            :lunar-base-1:
+              :name: Lunar Base 1
+              :hostname: lunar-base-1.power-iaas.cloud.ibm.com
+              :description: Lunar Base 1
+            :lunar-base-2:
+              :name: Lunar Base 2
+              :hostname: lunar-base-2.power-iaas.cloud.ibm.com
+              :description: Lunar Base 2
+
+5.  Click **Save**.

--- a/managing_providers/cloud_providers/_topics/disabling_amazon_cloud_regions.md
+++ b/managing_providers/cloud_providers/_topics/disabling_amazon_cloud_regions.md
@@ -5,16 +5,15 @@ the appliance server. Use this capability to disable certain classified
 regions like AWS GovCloud. Once disabled, the region will not be
 available when adding an Amazon EC2 provider.
 
-1.  Click ![config gear](../../images/config-gear.png) (**Configuration**).
+1.  Click ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
 
-2.  Click on the **Settings** accordion, then click **Zones**.
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the additional
+    region to that server only.
 
-3.  Click the zone where the {{ site.data.product.title_short }} server is located,
-    then click on the EVM server.
+3.  Click on the **Advanced** tab.
 
-4.  Click on the **Advanced** tab.
-
-5.  Search for `:ems_amazon:`, and enter the regions you want to disable
+4.  Search for `:ems_amazon:`, and enter the regions you want to disable
     under `:disabled_regions:`.
 
         Example. To disable the `ap-northeast-1` region:
@@ -24,4 +23,4 @@ available when adding an Amazon EC2 provider.
           - us-gov-west-1
           - ap-northeast-1
 
-6.  Click **Save**.
+5.  Click **Save**.

--- a/managing_providers/cloud_providers/_topics/disabling_azure_cloud_regions.md
+++ b/managing_providers/cloud_providers/_topics/disabling_azure_cloud_regions.md
@@ -5,9 +5,11 @@ the appliance server. You can use this capability to disable certain
 classified regions. Once disabled, the region will not be available when
 adding a new Azure provider.
 
-1.  Click ![config gear](../../images/config-gear.png) (**Configuration**).
+1.  Click ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
 
-2.  Click on the **Settings** accordion, then click **Zones**.
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the disabled
+    region to that server only.
 
 3.  Click the zone where the {{ site.data.product.title_short }} server is located,
     then click on the EVM server.

--- a/managing_providers/cloud_providers/_topics/disabling_ibm_cloud_vpc_regions.md
+++ b/managing_providers/cloud_providers/_topics/disabling_ibm_cloud_vpc_regions.md
@@ -1,0 +1,26 @@
+## Disabling IBM Cloud VPC Regions
+
+{{ site.data.product.title_short }} allows administrators to disable IBM Cloud
+VPC regions on the appliance server. You can use this capability to disable
+certain classified regions. Once disabled, the region will not be available
+when adding a new IBM Cloud VPC provider.
+
+1.  Browse to ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
+
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the disabled
+    region to that server only.
+
+3.  Click on the **Advanced** tab.
+
+4.  Search for `:ems_ibm_cloud_vpc`, and enter the regions you want to disable
+    under `:disabled_regions:`.
+
+        Example. To disable the `au-syd` and `br-sao` regions:
+
+        :ems_ibm_cloud_vpc:
+          :disabled_regions:
+          - au-syd
+          - br-sao
+
+5.  Click **Save**.

--- a/managing_providers/cloud_providers/_topics/disabling_ibm_power_systems_virtual_servers_regions.md
+++ b/managing_providers/cloud_providers/_topics/disabling_ibm_power_systems_virtual_servers_regions.md
@@ -1,0 +1,26 @@
+## Disabling IBM Power Systems Virtual Server Regions
+
+{{ site.data.product.title_short }} allows administrators to disable IBM Power
+Systems Virtual Server regions on the appliance server. You can use this
+capability to disable default regions. Once disabled, the region will not be
+available for new and existing IBM Power Systems Virtual Server providers.
+
+1.  Browse to ![config gear](../../images/config-gear.png) **Settings** > **Application Settings**.
+
+2.  Click on the **Settings** accordion, then click **{{ site.data.product.title_short }}: Region** at the top.
+    Optionally, a server can be selected (within Zones) to limit the disabled
+    region to that server only.
+
+3.  Click on the **Advanced** tab.
+
+4.  Search for `:ems_ibm_cloud_power_virtual_servers:`, and enter the regions you want to disable
+    under `:disabled_regions:`.
+
+        Example. To disable the `dal` and `eu-de` regions:
+
+        :ems_ibm_cloud_power_virtual_servers:
+          :disabled_regions:
+          - dal
+          - eu-de
+
+5.  Click **Save**.

--- a/managing_providers/cloud_providers/ibm_cloud_vpc_providers.md
+++ b/managing_providers/cloud_providers/ibm_cloud_vpc_providers.md
@@ -10,3 +10,7 @@
 {% include_relative _topics/configuring_ibm_cloud_vpc_metrics_collection.md %}
 
 {% include_relative _topics/configuring_ibm_cloud_vpc_events.md %}
+
+{% include_relative _topics/adding_ibm_cloud_vpc_regions.md %}
+
+{% include_relative _topics/disabling_ibm_cloud_vpc_regions.md %}

--- a/managing_providers/cloud_providers/ibm_power_systems_virtual_servers_providers.md
+++ b/managing_providers/cloud_providers/ibm_power_systems_virtual_servers_providers.md
@@ -6,3 +6,7 @@
 {% include_relative _topics/overview_ibm_cloud_powervs.md %}
 
 {% include_relative _topics/adding_ibm_cloud_powervs_providers.md %}
+
+{% include_relative _topics/adding_ibm_power_systems_virtual_servers_regions.md %}
+
+{% include_relative _topics/disabling_ibm_power_systems_virtual_servers_regions.md %}


### PR DESCRIPTION
1. Fix some minor menu labeling in the existing AWS ans Azure add/disable provider region docs
2. Add new add/disable provider region docs for IBM Cloud VPC and PowerVS providers