### PR TITLE
Mention optional messaging disk in requirements

### DIFF
--- a/_includes/introduction.md
+++ b/_includes/introduction.md
@@ -70,7 +70,7 @@ minimum:
 
   - 12 GB RAM
 
-  - 44 GB HDD + optional database disk
+  - 44 GB HDD + optional database disk + optional messaging disk
 
 #### Database Requirements
 


### PR DESCRIPTION
Since we allow a disk in messaging configuration we should mention it as an optional requirement. There was some confusion with users differentiating between the disk prompt in messaging and the optional db disk requirement listed here

@miq-bot assign @agrare 
@miq-bot add_label enhancement, radjabov/yes?
@miq-bot add_reviewer @agrare 