### PR TITLE
Fix indenting issue in site_menu

### DIFF
--- a/_data/site_menu.yml
+++ b/_data/site_menu.yml
@@ -4,36 +4,36 @@ installing:
   title: Installing
   children:
     - title: Containerized (podified)
-        children:
-           - title: Kubernetes
-             path: "/docs/reference/latest/installing_on_kubernetes/index.html"
-             desc: "How to install and configure ManageIQ on Kubernetes"
+      children:
+        - title: Kubernetes
+          path: "/docs/reference/latest/installing_on_kubernetes/index.html"
+          desc: "How to install and configure ManageIQ on Kubernetes"
     - title: Appliance
-        children:
-           - title: Amazon Web Services (AWS)
-             path: "/docs/reference/latest/installing_on_aws/index.html"
-             desc: "How to install and configure the ManageIQ on Amazon Web Services (AWS)"
-           - title: IBM Cloud
-             path: "/docs/reference/latest/installing_on_ibm_cloud/index.html"
-             desc: "How to install and configure the ManageIQ on IBM Cloud"
-           - title: Microsoft Azure
-             path: "/docs/reference/latest/installing_on_microsoft_azure/index.html"
-             desc: "How to install and configure the ManageIQ on Microsoft Azure"
-           - title: Google Compute Engine
-             path: "/docs/reference/latest/installing_on_google_compute_engine/index.html"
-             desc: "How to install and configure the ManageIQ on Google Compute Engine"
-           - title: VMware vSphere
-             path: "/docs/reference/latest/installing_on_vmware_vsphere/index.html"
-             desc: "How to install and configure the ManageIQ on VMware vSphere"
-           - title: Red Hat Enterprise OpenStack Platform
-             path: "/docs/reference/latest/installing_on_red_hat_enterprise_linux_openstack_platform/index.html"
-             desc: "How to install and configure the ManageIQ on Red Hat OpenStack Platform"
-           - title: Red Hat Enterprise Virtualization
-             path: "/docs/reference/latest/installing_on_red_hat_virtualization/index.html"
-             desc: "How to install and configure the ManageIQ on Red Hat Enterprise Virtualization"
-           - title: Microsoft System Center Virtual Machine Manager (SCVMM)
-             path: "/docs/reference/latest/installing_on_scvmm/index.html"
-             desc: "How to install and configure the ManageIQ on Microsoft System Center Virtual Machine Manager (SCVMM)"
+      children:
+        - title: Amazon Web Services (AWS)
+          path: "/docs/reference/latest/installing_on_aws/index.html"
+          desc: "How to install and configure the ManageIQ on Amazon Web Services (AWS)"
+        - title: IBM Cloud
+          path: "/docs/reference/latest/installing_on_ibm_cloud/index.html"
+          desc: "How to install and configure the ManageIQ on IBM Cloud"
+        - title: Microsoft Azure
+          path: "/docs/reference/latest/installing_on_microsoft_azure/index.html"
+          desc: "How to install and configure the ManageIQ on Microsoft Azure"
+        - title: Google Compute Engine
+          path: "/docs/reference/latest/installing_on_google_compute_engine/index.html"
+          desc: "How to install and configure the ManageIQ on Google Compute Engine"
+        - title: VMware vSphere
+          path: "/docs/reference/latest/installing_on_vmware_vsphere/index.html"
+          desc: "How to install and configure the ManageIQ on VMware vSphere"
+        - title: Red Hat Enterprise OpenStack Platform
+          path: "/docs/reference/latest/installing_on_red_hat_enterprise_linux_openstack_platform/index.html"
+          desc: "How to install and configure the ManageIQ on Red Hat OpenStack Platform"
+        - title: Red Hat Enterprise Virtualization
+          path: "/docs/reference/latest/installing_on_red_hat_virtualization/index.html"
+          desc: "How to install and configure the ManageIQ on Red Hat Enterprise Virtualization"
+        - title: Microsoft System Center Virtual Machine Manager (SCVMM)
+          path: "/docs/reference/latest/installing_on_scvmm/index.html"
+          desc: "How to install and configure the ManageIQ on Microsoft System Center Virtual Machine Manager (SCVMM)"
 
 upgrading:
   title: Upgrading


### PR DESCRIPTION
Fixes a bug introduced in #1806 where the indenting was causing 

```
Psych::SyntaxError: (/tmp/manageiq-documentation/_data/site_menu.yml): mapping values are not allowed in this context at line 7 column 17
```

I don't understand why that PR didn't fail considering it does a full build, but I have a feeling it's not using the PR for the build, but instead using master.

@jrafanie Please review.