### PR TITLE
Differentiate between Kubevirt and OpenShift Virtualization

### DIFF
--- a/_includes/provider-ocp-add-container.md
+++ b/_includes/provider-ocp-add-container.md
@@ -109,7 +109,7 @@
 
 9. In the **Virtualization** endpoint tab optionally configure the virtualization service details:
 
-    1. Select a service type (OpenShift Virtualization / KubeVirt) or leave disabled
+    1. Select a service type (OpenShift Virtualization) or leave disabled
 
     2.  Select a **Security Protocol** method to specify how to
         authenticate the service:

--- a/capabilities_matrix/_topics/providers.md
+++ b/capabilities_matrix/_topics/providers.md
@@ -23,6 +23,7 @@ The following table lists providers that {{ site.data.product.title_short }} can
 | [Microsoft Azure Stack](#cloud-providers)                                            |
 | [Microsoft System Center Virtual Machine Manager (SCVMM)](#infrastructure-providers) |
 | [Nuage Networks](#network-providers)                                                 |
+| [OpenShift Virtualization](#infrastructure-providers)                                |
 | [OpenStack](#cloud-providers)                                                        |
 | [Oracle Cloud](#cloud-providers)                                                     |
 | [oVirt](#infrastructure-providers)                                                   |


### PR DESCRIPTION
Post subclassing OSV, we should differentiate it as a separate provider from Kubevirt in the docs

@miq-bot assign @agrare 
@miq-bot add_labels enhancement, radjabov/yes?
@miq-bot add_reviewers @agrare, @Fryguy 