### PR TITLE
QA Minor change to OpenTofu command description.

### DIFF
--- a/_data/product.yml
+++ b/_data/product.yml
@@ -12,4 +12,5 @@ operator_directory: https://github.com/ManageIQ/manageiq-pods/tree/master/manage
 operator_namespace: manageiq.org
 workflow_service_account: manageiq-default
 import_opentofu: runuser --login manageiq --command 'podman --root=/var/www/miq/vmdb/data/containers/storage image load --input /tmp/<OpenTofu_image>'
+opentofu_image_name: `<OpenTofu_image>`
 container_image: docker.io/manageiq/opentofu-runner:latest

--- a/managing_providers/_topics/automation_management_providers.md
+++ b/managing_providers/_topics/automation_management_providers.md
@@ -384,7 +384,7 @@ Use the following command to import the OpenTofu image on your appliance server.
 {{ site.data.product.import_opentofu }}
 ```
 
-Where `OpenTofu_image` is the name of your OpenTofu image.
+Where {{ site.data.product.opentofu_image_name }} is the name of your OpenTofu image.
 
 You also need to set the docker image name in advanced settings before enabling the server role. Navigate to the **Settings** > **Application Settings** in {{ site.data.product.title_short }} UI and set the value for `workers/worker_base/opentofu_worker/container_image` field.
 


### PR DESCRIPTION
Used variable `opentofu_image_name: <OpenTofu_image>` in upstream.

Will change variable to correct value for downstream by using the same file in `infra-mgmt-docs` repo.

https://jsw.ibm.com/browse/CP4AIOPS-8506