### PR TITLE
Fix issue with invalid yaml

### DIFF
--- a/_data/product.yml
+++ b/_data/product.yml
@@ -12,5 +12,5 @@ operator_directory: https://github.com/ManageIQ/manageiq-pods/tree/master/manage
 operator_namespace: manageiq.org
 workflow_service_account: manageiq-default
 import_opentofu: runuser --login manageiq --command 'podman --root=/var/www/miq/vmdb/data/containers/storage image load --input /tmp/<OpenTofu_image>'
-opentofu_image_name: `<OpenTofu_image>`
+opentofu_image_name: <OpenTofu_image>
 container_image: docker.io/manageiq/opentofu-runner:latest

--- a/managing_providers/_topics/automation_management_providers.md
+++ b/managing_providers/_topics/automation_management_providers.md
@@ -384,7 +384,7 @@ Use the following command to import the OpenTofu image on your appliance server.
 {{ site.data.product.import_opentofu }}
 ```
 
-Where {{ site.data.product.opentofu_image_name }} is the name of your OpenTofu image.
+Where `{{ site.data.product.opentofu_image_name }}` is the name of your OpenTofu image.
 
 You also need to set the docker image name in advanced settings before enabling the server role. Navigate to the **Settings** > **Application Settings** in {{ site.data.product.title_short }} UI and set the value for `workers/worker_base/opentofu_worker/container_image` field.
 
@@ -538,4 +538,3 @@ Use the following steps to run the Terraform Template.
 {{ site.data.product.title_short }} takes you to the *Requests queue* page and displays the status of the job.
 
 The service item details can be viewed when you navigate to **Services** > **My Services in {{ site.data.product.title_short }}**.
-


### PR DESCRIPTION
The backtick is not a valid starting char in YAML, but also we shouldn't use formatting in the YAML, because it won't be redenered properly anyway.

I'm not sure why #1821 went green, but that introduced the issue.

@agrare Please review
cc @qahmed1998 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
