### PR TITLE
QA Added link for CIC within Cloud Providers section

### DIFF
--- a/managing_providers/_topics/cloud_providers.md
+++ b/managing_providers/_topics/cloud_providers.md
@@ -47,6 +47,8 @@ Provider authentication status
 
 * [Google Compute Engine Providers](./cloud_providers/google_compute_engine_providers.html)
 
+* [IBM CIC Providers](./cloud_providers/ibm_cic_providers.html)
+
 * [IBM Cloud VPC Provider](./cloud_providers/ibm_cloud_vpc_providers.html)
 
 * [IBM Power Systems Virtual Servers Providers](./cloud_providers/ibm_power_systems_virtual_servers_providers.html)


### PR DESCRIPTION
Added a link for CIC providers under Cloud providers section. Changes need to go to `cp4waiops-4.8.1` in infra repo.

@miq-bot assign @Fryguy 

@miq-bot add_labels radjabov/yes?