### PR TITLE
Fix image URLs + minor edits for text to appear correctly on line

### DIFF
--- a/managing_providers/cloud_providers/_topics/adding_azure_providers.md
+++ b/managing_providers/cloud_providers/_topics/adding_azure_providers.md
@@ -67,14 +67,14 @@ you need to register the Microsoft Insights resource provider.
 2. Enter **microsoft.insights** in the search box.
 3. If the provider isn't registered, then select the checkbox, and click **Register**.
 
-![Microsoft Insights Resource Provider](../../../images/azure-microsoft-insights.png)
+![Microsoft Insights Resource Provider](../../images/azure-microsoft-insights.png)
 
 **Add an Azure Cloud Provider**:
 
 1.  Browse to the menu and click **Compute** > **Clouds** > **Providers**.
 
 2.  Click **Configuration**, then click
-    ![1862](../../../images/1862.png) (**Add a New Cloud Provider**).
+    ![1862](../../images/1862.png) (**Add a New Cloud Provider**).
 
 3.  Enter a **Name** for the provider.
 

--- a/managing_providers/cloud_providers/_topics/adding_google_compute_engine_providers.md
+++ b/managing_providers/cloud_providers/_topics/adding_google_compute_engine_providers.md
@@ -28,7 +28,7 @@ To add a Google Compute Engine provider to {{ site.data.product.title_short }}, 
 1.  Browse to menu: **Compute > Clouds > Providers**.
 
 2.  Click **Configuration**, then click
-    ![1862](../images/1862.png) (**Add a New Cloud Provider**).
+    ![1862](../../images/1862.png) (**Add a New Cloud Provider**).
 
 3.  Enter a **Name** for the provider.
 

--- a/managing_providers/cloud_providers/_topics/enabling_gce_events.md
+++ b/managing_providers/cloud_providers/_topics/enabling_gce_events.md
@@ -21,7 +21,7 @@ in {{ site.data.product.title_short }}.
 
 1.  In Google Cloud Platform, select your project from the top menu bar.
 
-2.  Click ![gce products services](../images/gce-products-services.png) to
+2.  Click ![gce products services](../../images/gce-products-services.png) to
     show the **Products and Services** menu. Click **API Manager** to go
     to <https://console.cloud.google.com/apis/library/>.
 
@@ -41,7 +41,7 @@ in {{ site.data.product.title_short }}.
 <!-- end list -->
 
 1.  In Google Cloud Platform, select your project and browse to ![gce
-    products services](../images/gce-products-services.png) **Products
+    products services](../../images/gce-products-services.png) **Products
     and Services > IAM & Admin > IAM** to go to
     <https://console.cloud.google.com/iam-admin/iam/>.
 
@@ -71,7 +71,7 @@ Compute Engine project to export events to {{ site.data.product.title_short }} w
 following steps:
 
 1.  In Google Cloud Platform, click ![gce products
-    services](../images/gce-products-services.png) to show the **Products
+    services](../../images/gce-products-services.png) to show the **Products
     and Services** menu, and click **Logging** to go to
     <https://console.cloud.google.com/logs/>.
 
@@ -90,7 +90,7 @@ following steps:
 7.  In the **Create Cloud Pub/Sub Topic** dialog, enter
     `manageiq-activity-log` as the **Name**. Click **Create**.
 
-    ![gce exports](../images/gce-exports.png)
+    ![gce exports](../../images/gce-exports.png)
 
 8.  Click **Save**.
 

--- a/managing_providers/storage_providers/ibm_cloud_object_storage_managers.md
+++ b/managing_providers/storage_providers/ibm_cloud_object_storage_managers.md
@@ -22,13 +22,17 @@ For a list of supported regions please refer to this [page](https://cloud.ibm.co
 1. [Create](https://cloud.ibm.com/objectstorage/create) new Cloud Object Storage instance in IBM Cloud Console.
 
 2. Create access credentials by navigating to **Service Credentials -> New Credential** in your new instance.
+
    ![Import Image Button Screenshot](../../images/new_cos_creds.png)
+
    Make sure to choose the **Manager** role and to enable **Include HMAC Credential** option.
 
 3. Next navigate to `Manage -> Access (IAM) -> Service IDs`, find your newly created credential and edit it.
+
    ![pvc_reg](../../images/cos_access_policies.png)
 
 4. Select `Viewer` checkbox under `Platform Access` group and press `Add`.
+
    ![pvc_reg](../../images/cos_viewer.png)
 
 5. Browse to {{ site.data.product.title_short }} menu **Storage > Managers**.

--- a/provisioning_virtual_machines_and_hosts/_topics/cfme_lifecycle.md
+++ b/provisioning_virtual_machines_and_hosts/_topics/cfme_lifecycle.md
@@ -37,4 +37,6 @@ pre-processing and post-processing. Pre-processing acquires IP addresses
 for the user, creates CMDB instances, and creates the virtual machine or
 instance based on information in the request. Post-processing activates
 the CMDB instance and emails the user. The steps for provisioning may be
-modified at any time using {{ site.data.product.title_short }}. ![2314](../images/2314.png)
+modified at any time using {{ site.data.product.title_short }}. 
+
+![2314](../images/2314.png)

--- a/provisioning_virtual_machines_and_hosts/_topics/provisioning_requests.md
+++ b/provisioning_virtual_machines_and_hosts/_topics/provisioning_requests.md
@@ -17,7 +17,9 @@ The following options are available when making provisioning requests:
 
   - Customize the guest operating system
 
-  - Schedule the provisioning ![2315](../images/2315.png)
+  - Schedule the provisioning 
+
+  ![2315](../images/2315.png)
 
 ### Requirements for Provisioning Virtual Machines and Instances
 


### PR DESCRIPTION
Some of the images do not show on ManageIQ site and AIOps documentation. Fixed the path for images + minor edits to some lines where text was not showing correctly in the docs.

@miq-bot assign @Fryguy 
@miq-bot add_labels radjabov/yes?

Example of issues in downstream docs:

![image](https://github.com/user-attachments/assets/e2c82ea1-50d6-4b29-bb91-3b56aec0f8bc)
![image](https://github.com/user-attachments/assets/c51477e7-7207-4d01-b8dc-3715fee0af8b)
