### PR TITLE
QA Addition of RHEL in Capabilities matrix

### DIFF
--- a/capabilities_matrix/_topics/smartstate_analysis.md
+++ b/capabilities_matrix/_topics/smartstate_analysis.md
@@ -24,6 +24,7 @@
 | XFS         | Linux     | ✅            |
 | ReiserFS    | Linux     | ✅            |
 | CDfs        | Linux     | ✅            |
+| RPM (RHEL 6, 7, 8, 9) | Linux | ✅      |
 
 
 #### File Formats


### PR DESCRIPTION
Addition of RHEL (6,7,8,9) in capabilities matrix.

Doc issue: https://jsw.ibm.com/browse/CP4AIOPS-6891