### PR TITLE
QA Fixed the file formats table for RHEL

### DIFF
--- a/capabilities_matrix/_topics/smartstate_analysis.md
+++ b/capabilities_matrix/_topics/smartstate_analysis.md
@@ -24,7 +24,6 @@
 | XFS         | Linux     | ✅            |
 | ReiserFS    | Linux     | ✅            |
 | CDfs        | Linux     | ✅            |
-| RPM (RHEL 6, 7, 8, 9) | Linux | ✅      |
 
 
 #### File Formats
@@ -40,7 +39,7 @@
 | SQLite            | Linux     | ✅            |
 | Berkeley DB (BDB) | Linux     | ✅            |
 | Conary            | Linux     | ✅            |
-| RPM               | Linux     | ✅            |
+| RPM (RHEL 6, 7, 8, 9)  | Linux  | ✅          |
 | /etc/passwd       | Linux     | ✅            |
 | /etc/group        | Linux     | ✅            |
 | /etc/init.d       | Linux     | ✅            |


### PR DESCRIPTION
This PR fixes #1838 the File Formats table for RHEL. The RHEL version entry was added to File Systems table. The entry needs to be in File Formats table.
