### PR TITLE
Add instructions on installing WebMKS on containers

### DIFF
--- a/_includes/installing-vmware-webmks-containers.md
+++ b/_includes/installing-vmware-webmks-containers.md
@@ -1,0 +1,51 @@
+### Installing VMware WebMKS on containers
+
+VMware vSphere Virtual Machine Remote console access requires the installation of the VMware WebMKS SDK.
+Due to license restrictions this SDK cannot be built in to {{ site.data.product.title_short }}
+
+To install the WebMKS SDK on containers we can take an existing container and create another layer on top of it.  Once built, this image will need to be pushed to a registry and the CR updated to reflect that.
+
+1. Download the latest WebMKS version (e.g. `WebMKS_SDK_{version}.zip`) from the VMware website.
+
+2. Set up a temporary directory where we will build the image
+
+   ```bash
+   $ mkdir -p /tmp/webmks_container/container-assets
+   ```
+
+3. Copy the tar file into the container-assets directory.  For example,
+
+   ```bash
+   $ unzip ~/Downloads/WebMKS_SDK_*.zip -d /tmp/webmks_container/container-assets
+   ```
+
+4. Add the following Dockerfile as `/tmp/webmks_container/Dockerfile` and substitute the second `FROM` based on the image and version that you're running.
+
+   ```dockerfile
+   FROM registry.access.redhat.com/ubi8/ubi as webmks
+
+   COPY container-assets/ /webmks/
+
+   ################################################################################
+
+   ### IMPORTANT: Modify the following image and tag as necessary to reflect the version that you're running
+   FROM your_registry.example.com/namespace/manageiq-ui-worker:latest
+
+   COPY --from=webmks /webmks/ /var/www/miq/vmdb/public/webmks
+   ```
+
+5. Build the image and tag it appropriately for your registry, then push it to the registry.
+
+   ```bash
+   $ cd /tmp/webmks_container/
+   $ docker build . -t your_registry.example.com/namespace/manageiq-ui-worker:latest_webmks
+   $ docker push your_registry.example.com/namespace/manageiq-ui-worker:latest_webmks
+   ```
+
+6. Update the CR to use the UI worker image you just pushed to the registry.
+
+   ```yaml
+   uiWorkerImage: your_registry.example.com/namespace/manageiq-ui-worker:latest_webmks
+   ```
+
+The operator will now update the orchestrator and worker deployments to reflect this change.

--- a/_includes/installing-vmware-webmks.md
+++ b/_includes/installing-vmware-webmks.md
@@ -1,0 +1,16 @@
+## Installing VMware WebMKS on appliances
+
+VMware vSphere Virtual Machine Remote console access requires the installation of the VMware WebMKS SDK.
+Due to license restrictions this SDK cannot be built in to {{ site.data.product.title_short }}
+
+1.  Log in to the {{ site.data.product.title_short }} user interface appliance
+    console as the root user.
+
+2.  On the {{ site.data.product.title_short }} user interface appliances, create a
+    folder titled `webmks` in the `/var/www/miq/vmdb/public/` directory.
+
+        /var/www/miq/vmdb/public/webmks
+
+3.  Download and extract the contents of [VMware WebMKS
+    SDK](https://www.vmware.com/support/developer/html-console/) into
+    the `webmks` folder.

--- a/installing_on_kubernetes/index.md
+++ b/installing_on_kubernetes/index.md
@@ -31,6 +31,8 @@
 
 {% include installing-vmware-vddk-containers.md %}
 
+{% include installing-vmware-webmks-containers.md %}
+
 # Uninstalling
 
 {% include_relative _topics/uninstalling.md %}

--- a/installing_on_vmware_vsphere/_topics/additional_configuration.md
+++ b/installing_on_vmware_vsphere/_topics/additional_configuration.md
@@ -1,6 +1,7 @@
 ## Additional Configuration for Appliances on VMware vSphere
 
 {% include installing-vmware-vddk.md %}
+{% include installing-vmware-webmks.md %}
 
 ### Tuning Appliance Performance
 

--- a/managing_infrastructure_and_inventory/_topics/vnc_and_spice_consoles.md
+++ b/managing_infrastructure_and_inventory/_topics/vnc_and_spice_consoles.md
@@ -129,22 +129,7 @@ machines that will be accessed through the HTML5 or VNC console on the
 
 7.  Click **OK**.
 
-## Configuring VMware WebMKS Support
-
-Complete the following steps to enable WebMKS support in
-{{ site.data.product.title_short }}.
-
-1.  Log in to the {{ site.data.product.title_short }} user interface appliance
-    console as the root user.
-
-2.  On the {{ site.data.product.title_short }} user interface appliances, create a
-    folder titled `webmks` in the `/var/www/miq/vmdb/public/` directory.
-
-        /var/www/miq/vmdb/public/webmks
-
-3.  Download and extract the contents of [VMware WebMKS
-    SDK](https://www.vmware.com/support/developer/html-console/) into
-    the `webmks` folder.
+{% include installing-vmware-webmks.md %}
 
 ## Opening a Console for a Virtual Machine
 


### PR DESCRIPTION
TODO
- [x] Test installing this on local container images

Following these instructions I ended up with `docker.io/agrare/manageiq-ui-worker:latest_webmks`, added this to my CR
```
$ cat config/samples/_v1alpha1_manageiq.yaml 
apiVersion: manageiq.org/v1alpha1
kind: ManageIQ
metadata:
  name: manageiq-sample
spec:
  applicationDomain: miqproject.apps-crc.testing
  uiWorkerImage: docker.io/agrare/manageiq-ui-worker:latest_webmks
```

And confirmed the `/var/www/miq/vmdb/public/webmks` directory and contents show up in the container's filesystem:
![image](https://github.com/user-attachments/assets/abb6b7a0-f171-4a6d-93e1-42c9226e53d4)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
