### PR TITLE
Add caveat about KubeVirt VMs from Instance Types

### DIFF
--- a/capabilities_matrix/_topics/infrastructure_providers.md
+++ b/capabilities_matrix/_topics/infrastructure_providers.md
@@ -46,7 +46,7 @@
 |   &nbsp;&nbsp;&bull; Sysprep Windows Templates               | ✅      | ✅          | ❌                      | ❌            | ❌          |
 |   &nbsp;&nbsp;&bull; Cloud-init                              | ❌      | ✅          | ❌                      | ❌            | ❌          |
 | VM Retirement                                                | ✅      | ✅          | ❌                      | ✅            | ✅         |
-| VM Reconfiguration                                           | ✅      | ✅          | ❌                      | ❌            | ✅          |
+| VM Reconfiguration                                           | ✅      | ✅          | ❌                      | ❌            | ✅ *        |
 |   &nbsp;&nbsp;&bull; Disk Addition                           | ✅      | ✅          | ❌                      | ❌            | ❌          |
 |   &nbsp;&nbsp;&bull; Network Interface Add/Remove            | ✅      | ✅          | ❌                      | ❌            | ❌          |
 | VM Snapshot Creation and Removal                             | ✅      | ✅          | ❌                      | ❌            | ❌          |
@@ -63,6 +63,8 @@
 | Delete Cloud Subnet                                          | ❌      | ✅          | ❌                      | ❌            | ❌          |
 | Create Network Router                                        | ❌      | ✅          | ❌                      | ❌            | ❌          |
 | Delete Network Router                                        | ❌      | ✅          | ❌                      | ❌            | ❌          |
+
+\* KubeVirt/OSV VMs created with an instance type are not supported for reconfigure
 
 #### Remote Consoles
 


### PR DESCRIPTION
Currently only KubeVirt VMs created from Templates work with VM Reconfigure.

Related: https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/296

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
