### PR TITLE
Fix link to download WebMKS SDK from broadcom.com

### DIFF
--- a/_includes/installing-vmware-webmks.md
+++ b/_includes/installing-vmware-webmks.md
@@ -12,5 +12,5 @@ Due to license restrictions this SDK cannot be built in to {{ site.data.product.
         /var/www/miq/vmdb/public/webmks
 
 3.  Download and extract the contents of [VMware WebMKS
-    SDK](https://www.vmware.com/support/developer/html-console/) into
+    SDK](https://developer.broadcom.com/sdks/vmware-html-console-sdk/latest/) into
     the `webmks` folder.


### PR DESCRIPTION
The vmware developer support web-console link no longer properly redirects to the right broadcom page.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
