### PR TITLE
Update workflows docs for changes in floe v0.17.0 and document builtin method parameters

### DIFF
--- a/managing_providers/_topics/embedded_workflows.md
+++ b/managing_providers/_topics/embedded_workflows.md
@@ -322,7 +322,7 @@ If the user is running an embedded workflow on OCP, and is using a docker reposi
 
 Long lived credentials like usernames and passwords should be defined as Mapped Credentials as described in `Adding Credentials`.
 
-Short lived credentials such as bearer tokens which are obtained while the workflow is running can be set as state output and stored securely in the Credentials field for further states.  This can be accomplished by using `ResultPath` with a path starting with `$.Credentials`.  This will set the output of the state in the `Credentials` payload.
+Short lived credentials such as bearer tokens which are obtained while the workflow is running can be set as state output and stored securely in the Credentials field for further states.  This can be accomplished by using `ResultPath` with a path starting with `$$.Credentials`.  This will set the output of the state in the `Credentials` payload.
 
 For an example lets say we have a State which takes a username and password and outputs a bearer token to be used later on:
 
@@ -331,10 +331,10 @@ For an example lets say we have a State which takes a username and password and 
   "Type": "Task",
   "Resource": "docker://login:latest",
   "Credentials": {
-    "username.$": "$.username",
-    "password.$": "$.password"
+    "username.$": "$$.Credentials.username",
+    "password.$": "$$.Credentials.password"
   },
-  "ResultPath": "$.Credentials",
+  "ResultPath": "$$.Credentials",
   "Next": "NextState"
 }
 ```
@@ -346,7 +346,7 @@ If the output of the docker image is `{"bearer_token":"abcd"}` then we will be a
   "Type": "Task",
   "Resource": "docker://do-something:latest",
   "Credentials": {
-    "token.$": "$.bearer_token"
+    "token.$": "$$.Credentials.bearer_token"
   }
 }
 ```
@@ -358,13 +358,13 @@ All of the normal Input/Output processing still applies so if you need to manipu
   "Type": "Task",
   "Resource": "docker://login:latest",
   "Credentials": {
-    "username.$": "$.username",
-    "password.$": "$.password"
+    "username.$": "$$.Credentials.username",
+    "password.$": "$$.Credentials.password"
   },
   "ResultSelector": {
     "bearer_token.$": "$.result"
   },
-  "ResultPath": "$.Credentials",
+  "ResultPath": "$$.Credentials",
   "Next": "NextState"
 }
 ```
@@ -376,10 +376,10 @@ We can also store the result in a parent node for organization:
   "Type": "Task",
   "Resource": "docker://login:latest",
   "Credentials": {
-    "username.$": "$.username",
-    "password.$": "$.password"
+    "username.$": "$$.Credentials.username",
+    "password.$": "$$.Credentials.password"
   },
-  "ResultPath": "$.Credentials.VMware",
+  "ResultPath": "$$.Credentials.VMware",
   "Next": "NextState"
 }
 ```
@@ -391,7 +391,7 @@ And then access it like:
   "Type": "Task",
   "Resource": "docker://do-something:latest",
   "Credentials": {
-    "token.$": "$.VMware.bearer_token"
+    "token.$": "$$.VMware.bearer_token"
   }
 }
 ```

--- a/managing_providers/_topics/embedded_workflows.md
+++ b/managing_providers/_topics/embedded_workflows.md
@@ -470,7 +470,7 @@ You can create a generic service catalog item that uses an embedded workflow. To
 
 ## Upgrading
 
-If you wrote a workflow on `spassky-1` or older you might have to update your workflow content.
+If you wrote a workflow with floe prior to `v0.17.0` you might have to update your workflow content.  You can check your floe version by using `bundle info floe`
 
 1. The Credentials Task property has changed to use `$$.Credentials` to access the credentials payload, `$.` will use state input which is consistent with the rest of Input/Output processing.  `ResultPath` also has to be updated to set credentials to `$$.Credentials`.
 

--- a/managing_providers/_topics/embedded_workflows.md
+++ b/managing_providers/_topics/embedded_workflows.md
@@ -467,3 +467,49 @@ You can create a generic service catalog item that uses an embedded workflow. To
    The list of services and requests is shown when the catalog item is submitted. Clicking the request shows the execution status, including any embedded workflows.
 
    ![Workflow Status](../images/embedworkflow_runstatus.png)
+
+## Upgrading
+
+If you wrote a workflow on `spassky-1` or older you might have to update your workflow content.
+
+1. The Credentials Task property has changed to use `$$.Credentials` to access the credentials payload, `$.` will use state input which is consistent with the rest of Input/Output processing.  `ResultPath` also has to be updated to set credentials to `$$.Credentials`.
+
+Example:
+```json
+{
+  "Type": "Task",
+  "Credentials": {"password.$": "$.Password"},
+  "ResultPath": "$.Credentials"
+}
+```
+
+Becomes:
+```json
+{
+  "Type": "Task",
+  "Credentials": {"password.$": "$$.Credentials.password"},
+  "ResultPath": "$$.Credentials"
+}
+```
+
+2. Nested hashes no longer require the key to have a `.$` suffix to perform interpolation
+
+Example:
+```json
+{
+  "Type": "Pass",
+  "Result": {
+    "Body.$": {"foo.$": "$.bar"}
+  }
+}
+```
+
+Becomes:
+```json
+{
+  "Type": "Pass",
+  "Result": {
+    "Body": {"foo.$": "$.bar"}
+  }
+}
+```


### PR DESCRIPTION
This updates the embedded_workflows docs to call out changes to Credentials handling and nested hash interpolation in floe 0.17.0
Also documents the builtin runner methods in floe and manageiq (floe://http was added in 0.17.0, we were missing any documentation on the manageiq:// ones so added those as well)
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
