### PR TITLE
Update openshift management token instructions

### DIFF
--- a/_includes/provider-ocp-mgt-token.md
+++ b/_includes/provider-ocp-mgt-token.md
@@ -1,18 +1,33 @@
 Run the following to obtain the token needed to add a Red Hat OpenShift provider:
 
-1.  Obtain the `management` service account token name:
+1. Obtain the service account token name:
+    ```bash
+    oc apply -f - <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+     name: $service_account_name-secret
+     namespace: $project_name
+     annotations:
+       kubernetes.io/service-account.name: $service_account_name
+    type: kubernetes.io/service-account-token
+    EOF
 
-        # oc describe sa -n $project_name $service_account_name
-        ...
-        Tokens:  management-admin-token-0f3fh
-                 management-admin-token-q7a87
+    oc describe secret -n $project_name $service_account_name-secret
+    Data
+    ====
+    service-ca.crt:  8422 bytes
+    token:           eyJhbGciOiJSUzI1N...
+    ```
+2. Select and describe one of the tokens to retrieve the full token
+   output, replacing `management-admin-token-0f3fh` with the name of
+   your token:
 
-2.  Select and describe one of the tokens to retrieve the full token
-    output, replacing `management-admin-token-0f3fh` with the name of
-    your token:
-
-        # oc describe secret -n $project_name management-admin-token-0f3fh
-        ...
-        Data
-        ====
-        token:  eyJhbGciOiJSUzI1NiI...
+   ```bash
+   oc describe secret -n $project_name $service_account_name-secret
+   ...
+   Data
+   ====
+   service-ca.crt:  8422 bytes
+   token:           eyJhbGciOiJSUzI1N...
+   ```

--- a/_includes/provider-ocp-mgt-token.md
+++ b/_includes/provider-ocp-mgt-token.md
@@ -1,6 +1,6 @@
 Run the following to obtain the token needed to add a Red Hat OpenShift provider:
 
-1. Obtain the service account token name:
+1. Create the service account token
     ```bash
     oc apply -f - <<EOF
     apiVersion: v1
@@ -12,22 +12,10 @@ Run the following to obtain the token needed to add a Red Hat OpenShift provider
        kubernetes.io/service-account.name: $service_account_name
     type: kubernetes.io/service-account-token
     EOF
-
-    oc describe secret -n $project_name $service_account_name-secret
-    Data
-    ====
-    service-ca.crt:  8422 bytes
-    token:           eyJhbGciOiJSUzI1N...
     ```
-2. Select and describe one of the tokens to retrieve the full token
-   output, replacing `management-admin-token-0f3fh` with the name of
-   your token:
+2. Describe the secret to retrieve the full token value:
 
    ```bash
-   oc describe secret -n $project_name $service_account_name-secret
-   ...
-   Data
-   ====
-   service-ca.crt:  8422 bytes
-   token:           eyJhbGciOiJSUzI1N...
+   oc get secret -o template --template {{.data.token}} -n $project_name $service_account_name-secret
+   eyJhbGciOiJSUzI1N...
    ```


### PR DESCRIPTION
Service Account Tokens are no longer automatically generated when the service account gets created, `oc sa new-token` is deprecated, and `oc create token` has a limited duration (even if it can be years) and has not well documented default.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount describes how to create a long-lived service account token which matches what `oc sa new-token` would generate.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
