### PR TITLE
Add documentation on increasing cloned vm disk size

### DIFF
--- a/api/appendices/advanced_provisioning.md
+++ b/api/appendices/advanced_provisioning.md
@@ -12,6 +12,8 @@ provisioning via /api/provision\_requests.
 
   - [Defining new Disks](#defining-new-disks)
 
+  - [Increasing the template disk size](#increasing-the-template-disk-size)
+
   - [Cloning Type](#cloning-type)
 
   - [Limit Template Selection](#limit-template-selection)
@@ -84,6 +86,18 @@ Example:
 "diskscsi1" : "0:0:8"
 "diskscsi1.datastore" : "storage1"
 "diskscsi1.backing.diskmode" : "independent_persistent"
+```
+
+### Increasing the template disk size
+
+The `allocated_disk_storage` attribute allows for the first disk on a VM to be increased in size
+after the clone operation is complete.  This is only supported for templates with 1 disk.
+The attribute's unit is gigabytes.
+
+This is supported by the VMware vSphere provider.
+
+```json
+allocated_disk_storage: 10
 ```
 
 ### Cloning Type


### PR DESCRIPTION
This option was added in https://github.com/ManageIQ/manageiq-providers-vmware/pull/839

Naturally there are a couple of "we'll get to this later" that we never did, and as such this only works for templates with a single disk.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
